### PR TITLE
[Feature/#3] BaseViewModel 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ktlint) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -171,6 +171,7 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin"}
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "j
 orbit-core = { group = "org.orbit-mvi", name = "orbit-core", version.ref = "orbit" }
 orbit-compose = { group = "org.orbit-mvi", name = "orbit-compose", version.ref = "orbit" }
 orbit-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbit" }
+orbit-test = { group = "org.orbit-mvi", name = "orbit-test", version.ref = "orbit" }
 
 ## retrofit
 retrofit-bom = { group = "com.squareup.retrofit2", name = "retrofit-bom", version.ref = "retrofit" }
@@ -110,6 +111,7 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+kotlin-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 
 ## Other
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -13,4 +13,8 @@ dependencies {
 
     implementation(libs.bundles.androidx.core)
     implementation(libs.bundles.orbit)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.orbit.test)
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.bitnagil.android.library)
     alias(libs.plugins.bitnagil.android.compose.library)
+    alias(libs.plugins.kotlin.parcelize)
 }
 
 android {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviIntent.kt
@@ -1,0 +1,3 @@
+package com.threegap.bitnagil.presentation.common.mviviewmodel
+
+interface MviIntent

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviSideEffect.kt
@@ -1,0 +1,3 @@
+package com.threegap.bitnagil.presentation.common.mviviewmodel
+
+interface MviSideEffect

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviState.kt
@@ -1,0 +1,5 @@
+package com.threegap.bitnagil.presentation.common.mviviewmodel
+
+import android.os.Parcelable
+
+interface MviState : Parcelable

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
@@ -4,34 +4,32 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
 abstract class MviViewModel<STATE : MviState, SIDE_EFFECT : MviSideEffect, INTENT : MviIntent>(
-    private val initState: STATE,
-    private val savedStateHandle: SavedStateHandle,
+    initState: STATE,
+    savedStateHandle: SavedStateHandle,
 ) : ContainerHost<STATE, SIDE_EFFECT>, ViewModel() {
-    override val container: Container<STATE, SIDE_EFFECT>
-        get() = container(initialState = initState, savedStateHandle = savedStateHandle)
+    override val container = container<STATE, SIDE_EFFECT>(initialState = initState, savedStateHandle = savedStateHandle)
 
-    val stateFlow: StateFlow<STATE> = container.stateFlow
+    val stateFlow: StateFlow<STATE> get() = container.stateFlow
+    val sideEffectFlow: Flow<SIDE_EFFECT> get() = container.sideEffectFlow
 
-    val sideEffectFlow: Flow<SIDE_EFFECT> = container.sideEffectFlow
+    suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.sendSideEffect(sideEffect: SIDE_EFFECT) = postSideEffect(sideEffect)
 
-    protected fun sendSideEffect(sideEffect: SIDE_EFFECT) =
+    protected abstract suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.reduceState(
+        intent: INTENT,
+        state: STATE,
+    ): STATE?
+
+    fun sendIntent(intent: INTENT) =
         intent {
-            postSideEffect(sideEffect)
-        }
-
-    protected abstract fun reduceState(intent: INTENT): STATE?
-
-    protected fun sendIntent(intent: INTENT) =
-        intent {
-            val newState = reduceState(intent)
+            val newState = reduceState(intent, state)
 
             newState?.let {
                 reduce { newState }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
@@ -20,7 +20,7 @@ abstract class MviViewModel<STATE : MviState, SIDE_EFFECT : MviSideEffect, INTEN
     val stateFlow: StateFlow<STATE> get() = container.stateFlow
     val sideEffectFlow: Flow<SIDE_EFFECT> get() = container.sideEffectFlow
 
-    suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.sendSideEffect(sideEffect: SIDE_EFFECT) = postSideEffect(sideEffect)
+    protected suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.sendSideEffect(sideEffect: SIDE_EFFECT) = postSideEffect(sideEffect)
 
     protected abstract suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.reduceState(
         intent: INTENT,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
@@ -1,0 +1,40 @@
+package com.threegap.bitnagil.presentation.common.mviviewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+
+abstract class MviViewModel<STATE : MviState, SIDE_EFFECT : MviSideEffect, INTENT : MviIntent>(
+    private val initState: STATE,
+    private val savedStateHandle: SavedStateHandle,
+) : ContainerHost<STATE, SIDE_EFFECT>, ViewModel() {
+    override val container: Container<STATE, SIDE_EFFECT>
+        get() = container(initialState = initState, savedStateHandle = savedStateHandle)
+
+    val stateFlow: StateFlow<STATE> = container.stateFlow
+
+    val sideEffectFlow: Flow<SIDE_EFFECT> = container.sideEffectFlow
+
+    protected fun sendSideEffect(sideEffect: SIDE_EFFECT) =
+        intent {
+            postSideEffect(sideEffect)
+        }
+
+    protected abstract fun reduceState(intent: INTENT): STATE?
+
+    protected fun sendIntent(intent: INTENT) =
+        intent {
+            val newState = reduceState(intent)
+
+            newState?.let {
+                reduce { newState }
+            }
+        }
+}

--- a/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
+++ b/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.threegap.bitnagil.presentation.common.mviviewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.parcelize.Parcelize
+import org.junit.Before
+import org.junit.Test
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.test.test
+
+@ExperimentalCoroutinesApi
+class MviViewModelTest {
+    private lateinit var sampleMviViewModel: SampleMviViewModel
+
+    @Before
+    fun setUp() {
+        sampleMviViewModel = SampleMviViewModel(initState = SampleState(), savedStateHandle = SavedStateHandle())
+    }
+
+    @Test
+    fun `state는 호출 순서대로 갱신되어야 한다`() =
+        runTest {
+            sampleMviViewModel.test(testScope = this) {
+                containerHost.sendIntent(SampleIntent.Increase(number = 1))
+                containerHost.sendIntent(SampleIntent.Decrease(number = 2))
+                containerHost.sendIntent(SampleIntent.Increase(number = 3))
+
+                expectState { SampleState() }
+                expectState { SampleState(count = 1) }
+                expectState { SampleState(count = -1) }
+                expectState { SampleState(count = 2) }
+            }
+        }
+
+    @Test
+    fun `state와 sideEffect는 호출 순서대로 갱신되어야 한다`() =
+        runTest {
+            sampleMviViewModel.test(testScope = this) {
+                containerHost.sendIntent(SampleIntent.Increase(number = 1))
+                containerHost.sendIntent(SampleIntent.Clear)
+                containerHost.sendIntent(SampleIntent.Decrease(number = 2))
+                containerHost.sendIntent(SampleIntent.Increase(number = 3))
+
+                expectState { SampleState() }
+                expectState { SampleState(count = 1) }
+                expectSideEffect(SampleSideEffect.ShowToast("Clear"))
+                expectState { SampleState() }
+                expectState { SampleState(count = -2) }
+                expectState { SampleState(count = 1) }
+            }
+        }
+
+    // only for test
+    private class SampleMviViewModel(
+        initState: SampleState,
+        savedStateHandle: SavedStateHandle,
+    ) : MviViewModel<SampleState, SampleSideEffect, SampleIntent>(initState, savedStateHandle) {
+        override suspend fun SimpleSyntax<SampleState, SampleSideEffect>.reduceState(
+            intent: SampleIntent,
+            state: SampleState,
+        ): SampleState? {
+            val newState =
+                when (intent) {
+                    is SampleIntent.Decrease -> state.copy(count = state.count - intent.number)
+                    is SampleIntent.Increase -> state.copy(count = state.count + intent.number)
+                    SampleIntent.Clear -> {
+                        sendSideEffect(sideEffect = SampleSideEffect.ShowToast("Clear"))
+                        state.copy(count = 0)
+                    }
+                }
+            return newState
+        }
+    }
+
+    @Parcelize
+    private data class SampleState(
+        val count: Int = 0,
+    ) : MviState
+
+    private sealed class SampleSideEffect : MviSideEffect {
+        data class ShowToast(val message: String) : SampleSideEffect()
+    }
+
+    private sealed class SampleIntent : MviIntent {
+        data class Increase(val number: Int) : SampleIntent()
+
+        data class Decrease(val number: Int) : SampleIntent()
+
+        object Clear : SampleIntent()
+    }
+}


### PR DESCRIPTION
# [ PR Content ]
앱 내 전체적으로 사용될 ViewModel의 기반인 MviViewModel 클래스를 구현합니다

## Related issue
- closed #3

## Screenshot 📸
- N/A

## Work Description
- MviViewModel 구현
- MviViewModel 관련 unitTest 작성

## To Reviewers 📢
- BaseViewModel 네이밍보다는 Mvi에 대한 기반 ViewModel이라는 뜻에서 MviViewModel이라고 명칭했습니다
- 간단한 사용법은 MviViewModelTest.kt 코드 내 존재하는 SampleMviViewModel을 참고해주시면 될 것 같습니다
- kotlin-parcelize의 경우, savedStateHandle 사용을 위해 추가했습니다
- 추가적인 궁금증 혹은 이상한 부분이 있다면 코멘트 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - MVI(Model-View-Intent) 아키텍처 지원을 위한 기본 인터페이스(MviIntent, MviSideEffect, MviState) 및 추상 ViewModel(MviViewModel) 추가
- **Chores**
    - Kotlin Parcelize 플러그인 및 관련 테스트 라이브러리(Orbit Test, Kotlin Coroutines Test) 의존성 추가 및 설정
- **Tests**
    - MVI ViewModel 동작 검증을 위한 테스트(MviViewModelTest) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->