### PR TITLE
[Fix/#12] ktlint적용시 어노테이션이 붙은 생성자에 대해 자동 줄바꿈을 하던 부분 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,4 @@ insert_final_newline = true
 tab_width = 4
 ij_kotlin_allow_trailing_comma = true
 ktlint_function_naming_ignore_when_annotated_with=Composable
+ktlint_standard_annotation = disabled


### PR DESCRIPTION
# [ PR Content ]
ktlint 적용시 Inject와 같은 어노테이션이 붙은 생성자에 대해 자동 줄바꿈을 하던 문제를 수정했습니다.

## Related issue
- closed #12

## Screenshot 📸
x

## Work Description
- .editorconfig 파일을 수정하여 이젠 어노테이션 관련해서 ktlint 규칙을 적용하지 않습니다.

## To Reviewers 📢
- 이전 프로젝트에서는 이런 경험이 없었어서 비교해봤더니, "org.jlleitschuh.gradle.ktlint" 플러그인에 대해 이전 프로젝트는 11.3.2 버젼을, 현재 프로젝트는 12.3.0 버젼을 사용하고 있었습니다.
- 버젼을 바꿔가며 적용해본 결과, 어노테이션이 붙은 생성자 관련한 문제는 12.0.0부터 발생했습니다.
- "org.jlleitschuh.gradle.ktlint" 플러그인이 11.6.3에서  12.0.0으로 업데이트되면서 해당 플러그인에서 사용하는 "com.pinterest.ktlint:ktlint-core"과 같은 ktlint 라이브러리의 버젼이 올라감을 확인했기에, 해당 부분에서 발생한 차이점이라고 판단됩니다.
  - 11.6.1 버젼의 libs.version.toml 파일 : https://github.com/JLLeitschuh/ktlint-gradle/blob/v11.6.1/plugin/gradle/libs.versions.toml
  - 12.0.0 버젼의 libs.version.toml 파일 : https://github.com/JLLeitschuh/ktlint-gradle/blob/v12.0.0/plugin/gradle/libs.versions.toml