### PR TITLE
[Feature/#24] 스플래시 화면 구현

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.threegap.bitnagil.presentation.home.HomeScreen
+import com.threegap.bitnagil.presentation.intro.IntroScreenContainer
 import com.threegap.bitnagil.presentation.login.LoginScreenContainer
+import com.threegap.bitnagil.presentation.splash.SplashScreenContainer
 
 @Composable
 fun MainNavHost(
@@ -17,6 +19,17 @@ fun MainNavHost(
         startDestination = navigator.startDestination,
         modifier = modifier,
     ) {
+        composable<Route.Splash> {
+            SplashScreenContainer(
+                navigateToIntro = { navigator.navController.navigate(Route.Intro) },
+                navigateToHome = { navigator.navController.navigate(Route.Home) },
+            )
+        }
+
+        composable<Route.Intro> {
+            IntroScreenContainer()
+        }
+
         composable<Route.Login> {
             LoginScreenContainer()
         }

--- a/app/src/main/java/com/threegap/bitnagil/MainNavigator.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavigator.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.rememberNavController
 class MainNavigator(
     val navController: NavHostController,
 ) {
-    val startDestination = Route.Login
+    val startDestination = Route.Splash
 }
 
 @Composable

--- a/app/src/main/java/com/threegap/bitnagil/Route.kt
+++ b/app/src/main/java/com/threegap/bitnagil/Route.kt
@@ -5,6 +5,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface Route {
     @Serializable
+    data object Splash : Route
+
+    @Serializable
+    data object Intro : Route
+
+    @Serializable
     data object Login : Route
 
     @Serializable

--- a/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStore.kt
+++ b/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStore.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 interface AuthTokenDataStore {
     val tokenFlow: Flow<AuthToken>
 
+    suspend fun hasToken(): Boolean
+
     suspend fun updateAuthToken(accessToken: String, refreshToken: String)
 
     suspend fun updateAccessToken(accessToken: String)

--- a/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
+++ b/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import com.threegap.bitnagil.datastore.auth.model.AuthToken
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 
 class AuthTokenDataStoreImpl(
     private val dataStore: DataStore<AuthToken>,
@@ -12,8 +13,10 @@ class AuthTokenDataStoreImpl(
 
     override suspend fun hasToken(): Boolean {
         return try {
-            val currentToken = dataStore.data.first()
-            !currentToken.accessToken.isNullOrEmpty() && !currentToken.refreshToken.isNullOrEmpty()
+            val currentToken = dataStore.data.firstOrNull()
+            currentToken?.let {
+                !it.accessToken.isNullOrEmpty() && !it.refreshToken.isNullOrEmpty()
+            } ?: false
         } catch (e: Exception) {
             false
         }

--- a/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
+++ b/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
@@ -3,11 +3,21 @@ package com.threegap.bitnagil.datastore.auth.storage
 import androidx.datastore.core.DataStore
 import com.threegap.bitnagil.datastore.auth.model.AuthToken
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
 class AuthTokenDataStoreImpl(
     private val dataStore: DataStore<AuthToken>,
 ) : AuthTokenDataStore {
     override val tokenFlow: Flow<AuthToken> = dataStore.data
+
+    override suspend fun hasToken(): Boolean {
+        return try {
+            val currentToken = dataStore.data.first()
+            !currentToken.accessToken.isNullOrEmpty() && !currentToken.refreshToken.isNullOrEmpty()
+        } catch (e: Exception) {
+            false
+        }
+    }
 
     override suspend fun updateAuthToken(accessToken: String, refreshToken: String) {
         try {

--- a/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
+++ b/core/datastore/src/main/java/com/threegap/bitnagil/datastore/auth/storage/AuthTokenDataStoreImpl.kt
@@ -3,7 +3,6 @@ package com.threegap.bitnagil.datastore.auth.storage
 import androidx.datastore.core.DataStore
 import com.threegap.bitnagil.datastore.auth.model.AuthToken
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 
 class AuthTokenDataStoreImpl(

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/datasource/AuthLocalDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/datasource/AuthLocalDataSource.kt
@@ -1,5 +1,7 @@
 package com.threegap.bitnagil.data.auth.datasource
 
 interface AuthLocalDataSource {
+    suspend fun hasToken(): Boolean
+
     suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthLocalDataSourceImpl.kt
@@ -8,6 +8,8 @@ class AuthLocalDataSourceImpl @Inject constructor(
     private val authTokenDataStore: AuthTokenDataStore,
 ) : AuthLocalDataSource {
 
+    override suspend fun hasToken(): Boolean = authTokenDataStore.hasToken()
+
     override suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit> =
         runCatching {
             authTokenDataStore.updateAuthToken(

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/repositoryimpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/repositoryimpl/AuthRepositoryImpl.kt
@@ -16,6 +16,8 @@ class AuthRepositoryImpl @Inject constructor(
         authRemoteDataSource.login(socialAccessToken, LoginRequestDto(socialType))
             .map { it.toDomain() }
 
+    override suspend fun hasToken(): Boolean = authLocalDataSource.hasToken()
+
     override suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit> =
         authLocalDataSource.updateAuthToken(accessToken, refreshToken)
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/repository/AuthRepository.kt
@@ -5,5 +5,7 @@ import com.threegap.bitnagil.domain.auth.model.AuthSession
 interface AuthRepository {
     suspend fun login(socialAccessToken: String, socialType: String): Result<AuthSession>
 
+    suspend fun hasToken(): Boolean
+
     suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/HasTokenUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/HasTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.threegap.bitnagil.domain.auth.usecase
+
+import com.threegap.bitnagil.domain.auth.repository.AuthRepository
+import javax.inject.Inject
+
+class HasTokenUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(): Boolean = authRepository.hasToken()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/intro/IntroScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/intro/IntroScreen.kt
@@ -1,0 +1,32 @@
+package com.threegap.bitnagil.presentation.intro
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun IntroScreenContainer() {
+    IntroScreen()
+}
+
+@Composable
+private fun IntroScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Text("인트로 화면")
+    }
+}
+
+@Preview
+@Composable
+private fun IntroScreenPreview() {
+    IntroScreen()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashScreen.kt
@@ -1,0 +1,49 @@
+package com.threegap.bitnagil.presentation.splash
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.threegap.bitnagil.presentation.splash.model.SplashSideEffect
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun SplashScreenContainer(
+    navigateToIntro: () -> Unit,
+    navigateToHome: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel(),
+) {
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is SplashSideEffect.NavigateToIntro -> navigateToIntro()
+            is SplashSideEffect.NavigateToHome -> navigateToHome()
+        }
+    }
+
+    SplashScreen()
+}
+
+@Composable
+private fun SplashScreen(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Text(
+            text = "야무진 로고 추가 예정",
+            modifier = Modifier
+                .align(Alignment.Center),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SplashScreenPreview() {
+    SplashScreen()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,66 @@
+package com.threegap.bitnagil.presentation.splash
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.domain.auth.usecase.HasTokenUseCase
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
+import com.threegap.bitnagil.presentation.splash.model.SplashIntent
+import com.threegap.bitnagil.presentation.splash.model.SplashSideEffect
+import com.threegap.bitnagil.presentation.splash.model.SplashState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val hasTokenUseCase: HasTokenUseCase,
+) : MviViewModel<SplashState, SplashSideEffect, SplashIntent>(
+    initState = SplashState(),
+    savedStateHandle = savedStateHandle,
+) {
+
+    init {
+        checkAutoLogin()
+    }
+
+    override suspend fun SimpleSyntax<SplashState, SplashSideEffect>.reduceState(
+        intent: SplashIntent,
+        state: SplashState,
+    ): SplashState? =
+        when (intent) {
+            is SplashIntent.SetLoading -> {
+                state.copy(isLoading = intent.isLoading)
+            }
+
+            is SplashIntent.NavigateToIntro -> {
+                sendSideEffect(SplashSideEffect.NavigateToIntro)
+                state.copy(isLoading = false)
+            }
+
+            is SplashIntent.NavigateToHome -> {
+                sendSideEffect(SplashSideEffect.NavigateToHome)
+                state.copy(isLoading = false)
+            }
+        }
+
+    private fun checkAutoLogin() {
+        viewModelScope.launch {
+            sendIntent(SplashIntent.SetLoading(true))
+            val delayDeferred = async { delay(2000L) }
+            val tokenDeferred = async { hasTokenUseCase() }
+
+            delayDeferred.await()
+            val hasToken = tokenDeferred.await()
+
+            if (hasToken) {
+                sendIntent(SplashIntent.NavigateToHome)
+            } else {
+                sendIntent(SplashIntent.NavigateToIntro)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashIntent.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.presentation.splash.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
+
+sealed class SplashIntent : MviIntent {
+    data class SetLoading(val isLoading: Boolean) : SplashIntent()
+    data object NavigateToIntro : SplashIntent()
+    data object NavigateToHome : SplashIntent()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashSideEffect.kt
@@ -1,0 +1,8 @@
+package com.threegap.bitnagil.presentation.splash.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
+
+sealed interface SplashSideEffect : MviSideEffect {
+    data object NavigateToIntro : SplashSideEffect
+    data object NavigateToHome : SplashSideEffect
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashState.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.presentation.splash.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviState
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SplashState(
+    val isLoading: Boolean = false,
+) : MviState


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
앱 진입 시 최초로 보여지는 스플래시 화면 및 자동 로그인 기능 구현

## Related issue
- closed #24

## Screenshot 📸
- N/A

## Work Description
- 스플래시 화면 구현
- 자동 로그인 기능 구현(토큰 값 유뮤에 따라 `intro`/`home`화면으로 진입되도록 설정)

## To Reviewers 📢
- 아직 구체적인 디자인이 나오지 않아 스플래시를 넘어가는 시간은 임의로 2초의 딜레이를 설정했습니다.
- 디자인 요구사항을 확인해보니 인트로 화면이 사용자에게 보여지는 경우가 [**1. 최초 앱 사용자, 2. 로그아웃 및 회원탈퇴 사용자**]로 정의되어 있어, 토큰값 유무만으로도 분기 처리가 가능하기에 "토큰값 유무"로 자동 로그인 기능을 구현했슴다!
- 추가로 안드로이드에서 기본 제공해 주는 스플래시 제거 작업은 디자인이 확정된 후 작업하는 게 더 변경 사항이 적을 거 같다고 판단하여 따로 구현하진 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 앱 실행 시 스플래시 화면과 인트로 화면이 추가되었습니다.
  * 자동 로그인 여부에 따라 스플래시 화면에서 홈 또는 인트로 화면으로 자동 이동됩니다.
  * 인트로 화면이 새롭게 제공됩니다.
  * 토큰 존재 여부를 확인하는 기능이 도입되어 인증 흐름이 개선되었습니다.

* **UI 개선**
  * 스플래시 및 인트로 화면의 기본 UI가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->