### PR TITLE
[Feature/#28] 약관동의 화면 구현

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
@@ -8,6 +8,7 @@ import com.threegap.bitnagil.presentation.home.HomeScreen
 import com.threegap.bitnagil.presentation.intro.IntroScreenContainer
 import com.threegap.bitnagil.presentation.login.LoginScreenContainer
 import com.threegap.bitnagil.presentation.splash.SplashScreenContainer
+import com.threegap.bitnagil.presentation.terms.TermsAgreementScreenContainer
 
 @Composable
 fun MainNavHost(
@@ -33,7 +34,17 @@ fun MainNavHost(
         }
 
         composable<Route.Login> {
-            LoginScreenContainer()
+            LoginScreenContainer(
+                navigateToHome = { navigator.navController.navigate(Route.Home) },
+                navigateToTermsAgreement = { navigator.navController.navigate(Route.TermsAgreement) },
+            )
+        }
+
+        composable<Route.TermsAgreement> {
+            TermsAgreementScreenContainer(
+                navigateToOnBoarding = { },
+                navigateToBack = { navigator.navController.popBackStack() },
+            )
         }
 
         composable<Route.Home> {

--- a/app/src/main/java/com/threegap/bitnagil/Route.kt
+++ b/app/src/main/java/com/threegap/bitnagil/Route.kt
@@ -11,6 +11,9 @@ sealed interface Route {
     data object Intro : Route
 
     @Serializable
+    data object TermsAgreement : Route
+
+    @Serializable
     data object Login : Route
 
     @Serializable

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/datasource/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/datasource/AuthRemoteDataSource.kt
@@ -1,8 +1,11 @@
 package com.threegap.bitnagil.data.auth.datasource
 
 import com.threegap.bitnagil.data.auth.model.request.LoginRequestDto
+import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequestDto
 import com.threegap.bitnagil.data.auth.model.response.LoginResponseDto
 
 interface AuthRemoteDataSource {
     suspend fun login(socialAccessToken: String, loginRequestDto: LoginRequestDto): Result<LoginResponseDto>
+
+    suspend fun submitAgreement(termsAgreementRequestDto: TermsAgreementRequestDto): Result<Unit>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.threegap.bitnagil.data.auth.datasourceimpl
 
 import com.threegap.bitnagil.data.auth.datasource.AuthRemoteDataSource
 import com.threegap.bitnagil.data.auth.model.request.LoginRequestDto
+import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequestDto
 import com.threegap.bitnagil.data.auth.model.response.LoginResponseDto
 import com.threegap.bitnagil.data.auth.service.AuthService
 import com.threegap.bitnagil.data.common.safeApiCall
@@ -13,5 +14,10 @@ class AuthRemoteDataSourceImpl @Inject constructor(
     override suspend fun login(socialAccessToken: String, loginRequestDto: LoginRequestDto): Result<LoginResponseDto> =
         safeApiCall {
             authService.postLogin(socialAccessToken, loginRequestDto)
+        }
+
+    override suspend fun submitAgreement(termsAgreementRequestDto: TermsAgreementRequestDto): Result<Unit> =
+        safeApiCall {
+            authService.submitAgreement(termsAgreementRequestDto)
         }
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/mapper/AuthMapper.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/mapper/AuthMapper.kt
@@ -7,11 +7,12 @@ import com.threegap.bitnagil.domain.auth.model.TermsAgreement
 import com.threegap.bitnagil.domain.auth.model.UserRole
 
 // toDomain
-internal fun LoginResponseDto.toDomain() = AuthSession(
-    accessToken = accessToken,
-    refreshToken = refreshToken,
-    role = UserRole.from(role),
-)
+internal fun LoginResponseDto.toDomain() =
+    AuthSession(
+        accessToken = this.accessToken,
+        refreshToken = this.refreshToken,
+        role = UserRole.from(this.role),
+    )
 
 // toDto
 internal fun TermsAgreement.toDto() =

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/mapper/AuthMapper.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/mapper/AuthMapper.kt
@@ -1,11 +1,22 @@
 package com.threegap.bitnagil.data.auth.mapper
 
+import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequestDto
 import com.threegap.bitnagil.data.auth.model.response.LoginResponseDto
 import com.threegap.bitnagil.domain.auth.model.AuthSession
+import com.threegap.bitnagil.domain.auth.model.TermsAgreement
 import com.threegap.bitnagil.domain.auth.model.UserRole
 
+// toDomain
 internal fun LoginResponseDto.toDomain() = AuthSession(
     accessToken = accessToken,
     refreshToken = refreshToken,
     role = UserRole.from(role),
 )
+
+// toDto
+internal fun TermsAgreement.toDto() =
+    TermsAgreementRequestDto(
+        agreedToTermsOfService = this.agreedToTermsOfService,
+        agreedToPrivacyPolicy = this.agreedToPrivacyPolicy,
+        isOverFourteen = this.isOverFourteen,
+    )

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/model/request/TermsAgreementRequestDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/model/request/TermsAgreementRequestDto.kt
@@ -1,0 +1,14 @@
+package com.threegap.bitnagil.data.auth.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsAgreementRequestDto(
+    @SerialName("agreedToTermsOfService")
+    val agreedToTermsOfService: Boolean,
+    @SerialName("agreedToPrivacyPolicy")
+    val agreedToPrivacyPolicy: Boolean,
+    @SerialName("isOverFourteen")
+    val isOverFourteen: Boolean,
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/repositoryimpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/repositoryimpl/AuthRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.threegap.bitnagil.data.auth.repositoryimpl
 import com.threegap.bitnagil.data.auth.datasource.AuthLocalDataSource
 import com.threegap.bitnagil.data.auth.datasource.AuthRemoteDataSource
 import com.threegap.bitnagil.data.auth.mapper.toDomain
+import com.threegap.bitnagil.data.auth.mapper.toDto
 import com.threegap.bitnagil.data.auth.model.request.LoginRequestDto
 import com.threegap.bitnagil.domain.auth.model.AuthSession
+import com.threegap.bitnagil.domain.auth.model.TermsAgreement
 import com.threegap.bitnagil.domain.auth.repository.AuthRepository
 import javax.inject.Inject
 
@@ -20,4 +22,9 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit> =
         authLocalDataSource.updateAuthToken(accessToken, refreshToken)
+
+    override suspend fun submitAgreement(termsAgreement: TermsAgreement): Result<Unit> =
+        authRemoteDataSource.submitAgreement(
+            termsAgreement.toDto(),
+        )
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/service/AuthService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/service/AuthService.kt
@@ -1,6 +1,7 @@
 package com.threegap.bitnagil.data.auth.service
 
 import com.threegap.bitnagil.data.auth.model.request.LoginRequestDto
+import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequestDto
 import com.threegap.bitnagil.data.auth.model.response.LoginResponseDto
 import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.Body
@@ -15,4 +16,9 @@ interface AuthService {
         @Header("SocialAccessToken") socialAccessToken: String,
         @Body loginRequestDto: LoginRequestDto,
     ): BaseResponse<LoginResponseDto>
+
+    @POST("/api/v1/auth/agreements")
+    suspend fun submitAgreement(
+        @Body termsAgreementRequestDto: TermsAgreementRequestDto,
+    ): BaseResponse<Unit>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/model/TermsAgreement.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/model/TermsAgreement.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.domain.auth.model
+
+data class TermsAgreement(
+    val agreedToTermsOfService: Boolean,
+    val agreedToPrivacyPolicy: Boolean,
+    val isOverFourteen: Boolean,
+) {
+    fun isValid(): Boolean = agreedToTermsOfService && agreedToPrivacyPolicy && isOverFourteen
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/model/TermsAgreement.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/model/TermsAgreement.kt
@@ -5,5 +5,6 @@ data class TermsAgreement(
     val agreedToPrivacyPolicy: Boolean,
     val isOverFourteen: Boolean,
 ) {
-    fun isValid(): Boolean = agreedToTermsOfService && agreedToPrivacyPolicy && isOverFourteen
+    val isValid: Boolean
+        get() = agreedToTermsOfService && agreedToPrivacyPolicy && isOverFourteen
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.threegap.bitnagil.domain.auth.repository
 
 import com.threegap.bitnagil.domain.auth.model.AuthSession
+import com.threegap.bitnagil.domain.auth.model.TermsAgreement
 
 interface AuthRepository {
     suspend fun login(socialAccessToken: String, socialType: String): Result<AuthSession>
@@ -8,4 +9,6 @@ interface AuthRepository {
     suspend fun hasToken(): Boolean
 
     suspend fun updateAuthToken(accessToken: String, refreshToken: String): Result<Unit>
+
+    suspend fun submitAgreement(termsAgreement: TermsAgreement): Result<Unit>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/SubmitTermsAgreementUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/SubmitTermsAgreementUseCase.kt
@@ -8,7 +8,7 @@ class SubmitTermsAgreementUseCase @Inject constructor(
     private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke(agreement: TermsAgreement): Result<Unit> {
-        if (!agreement.isValid()) {
+        if (!agreement.isValid) {
             return Result.failure(IllegalArgumentException("모든 필수 약관에 동의해야 합니다."))
         }
         return authRepository.submitAgreement(agreement)

--- a/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/SubmitTermsAgreementUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/auth/usecase/SubmitTermsAgreementUseCase.kt
@@ -1,0 +1,16 @@
+package com.threegap.bitnagil.domain.auth.usecase
+
+import com.threegap.bitnagil.domain.auth.model.TermsAgreement
+import com.threegap.bitnagil.domain.auth.repository.AuthRepository
+import javax.inject.Inject
+
+class SubmitTermsAgreementUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(agreement: TermsAgreement): Result<Unit> {
+        if (!agreement.isValid()) {
+            return Result.failure(IllegalArgumentException("모든 필수 약관에 동의해야 합니다."))
+        }
+        return authRepository.submitAgreement(agreement)
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
@@ -37,8 +37,8 @@ fun LoginScreenContainer(
                 // TODO: Navigate to Home
             }
 
-            is LoginSideEffect.NavigateToTermsOfService -> {
                 // TODO: Navigate to Terms of Service
+            is LoginSideEffect.NavigateToTermsAgreement -> {
             }
         }
     }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
@@ -21,6 +21,8 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun LoginScreenContainer(
+    navigateToHome: () -> Unit,
+    navigateToTermsAgreement: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -34,11 +36,11 @@ fun LoginScreenContainer(
             }
 
             is LoginSideEffect.NavigateToHome -> {
-                // TODO: Navigate to Home
+                navigateToHome()
             }
 
-                // TODO: Navigate to Terms of Service
             is LoginSideEffect.NavigateToTermsAgreement -> {
+                navigateToTermsAgreement()
             }
         }
     }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginViewModel.kt
@@ -37,7 +37,7 @@ class LoginViewModel @Inject constructor(
             is LoginIntent.LoginSuccess -> {
                 sendSideEffect(
                     if (intent.isGuest) {
-                        LoginSideEffect.NavigateToTermsOfService
+                        LoginSideEffect.NavigateToTermsAgreement
                     } else {
                         LoginSideEffect.NavigateToHome
                     },

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/model/LoginSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/model/LoginSideEffect.kt
@@ -5,5 +5,5 @@ import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
 sealed interface LoginSideEffect : MviSideEffect {
     data object RequestKakaoAccountLogin : LoginSideEffect
     data object NavigateToHome : LoginSideEffect
-    data object NavigateToTermsOfService : LoginSideEffect
+    data object NavigateToTermsAgreement : LoginSideEffect
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
@@ -180,7 +180,7 @@ private fun TermsAgreementScreen(
 
         Button(
             onClick = onStartButtonClick,
-            enabled = uiState.isAllAgreed,
+            enabled = uiState.submitEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
@@ -1,0 +1,208 @@
+package com.threegap.bitnagil.presentation.terms
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.threegap.bitnagil.presentation.terms.component.TermsAgreementItem
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementIntent
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementSideEffect
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun TermsAgreementScreenContainer(
+    navigateToOnBoarding: () -> Unit,
+    navigateToBack: () -> Unit,
+    viewmodel: TermsAgreementViewModel = hiltViewModel(),
+) {
+    val uiState by viewmodel.stateFlow.collectAsStateWithLifecycle()
+
+    viewmodel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is TermsAgreementSideEffect.NavigateToOnBoarding -> {
+                navigateToOnBoarding()
+            }
+
+            is TermsAgreementSideEffect.NavigateToBack -> {
+                navigateToBack()
+            }
+        }
+    }
+
+    TermsAgreementScreen(
+        uiState = uiState,
+        onToggleAllAgreements = {
+            viewmodel.sendIntent(TermsAgreementIntent.ToggleAllAgreements(it))
+        },
+        onToggleTermsOfService = {
+            viewmodel.sendIntent(TermsAgreementIntent.ToggleTermsOfService(it))
+        },
+        onTogglePrivacyPolicy = {
+            viewmodel.sendIntent(TermsAgreementIntent.TogglePrivacyPolicy(it))
+        },
+        onToggleOverFourteen = {
+            viewmodel.sendIntent(TermsAgreementIntent.ToggleOverFourteen(it))
+        },
+        onStartButtonClick = {
+            viewmodel.submitTermsAgreement()
+        },
+        onBackButtonClick = {
+            viewmodel.sendIntent(TermsAgreementIntent.BackButtonClick)
+        },
+    )
+}
+
+@Composable
+private fun TermsAgreementScreen(
+    uiState: TermsAgreementState,
+    onToggleAllAgreements: (Boolean) -> Unit,
+    onToggleTermsOfService: (Boolean) -> Unit,
+    onTogglePrivacyPolicy: (Boolean) -> Unit,
+    onToggleOverFourteen: (Boolean) -> Unit,
+    onStartButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(54.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "뒤로가기",
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .clickable(
+                        onClick = onBackButtonClick,
+                    ),
+            )
+
+            Text(
+                text = "이용약관",
+                color = Color.Black,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .padding(
+                    top = 48.dp,
+                )
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "빛나길 이용을 위해\n필수 약관에 동의해 주세요.",
+            )
+
+            Spacer(
+                modifier = Modifier.height(28.dp),
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp)
+                    .background(
+                        color = Color.LightGray,
+                        shape = RoundedCornerShape(10.dp),
+                    )
+                    .clickable { onToggleAllAgreements(!uiState.isAllAgreed) }
+                    .padding(
+                        vertical = 12.dp,
+                        horizontal = 16.dp,
+                    ),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = if (uiState.isAllAgreed) Color.Black else Color.Gray,
+                    modifier = Modifier.size(24.dp),
+                )
+                Text(
+                    text = "전체동의",
+                )
+            }
+
+            TermsAgreementItem(
+                title = "(필수) 서비스 이용약관 동의",
+                onCheckedChange = { onToggleTermsOfService(!uiState.agreedTermsOfService) },
+                isChecked = uiState.agreedTermsOfService,
+                showMore = true,
+            )
+
+            TermsAgreementItem(
+                title = "(필수) 개인정보 수집·이용 동의",
+                onCheckedChange = { onTogglePrivacyPolicy(!uiState.agreedPrivacyPolicy) },
+                isChecked = uiState.agreedPrivacyPolicy,
+                showMore = true,
+            )
+
+            TermsAgreementItem(
+                title = "(필수) 만 14세 이상입니다.",
+                onCheckedChange = { onToggleOverFourteen(!uiState.agreedOverFourteen) },
+                isChecked = uiState.agreedOverFourteen,
+            )
+        }
+
+        Button(
+            onClick = onStartButtonClick,
+            enabled = uiState.isAllAgreed,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 16.dp,
+                ),
+        ) {
+            Text("시작하기")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TermsAgreementScreenPreview() {
+    TermsAgreementScreen(
+        uiState = TermsAgreementState(),
+        onToggleAllAgreements = {},
+        onToggleTermsOfService = {},
+        onTogglePrivacyPolicy = {},
+        onToggleOverFourteen = {},
+        onStartButtonClick = {},
+        onBackButtonClick = {},
+    )
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
@@ -1,0 +1,90 @@
+package com.threegap.bitnagil.presentation.terms
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.domain.auth.model.TermsAgreement
+import com.threegap.bitnagil.domain.auth.usecase.SubmitTermsAgreementUseCase
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementIntent
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementSideEffect
+import com.threegap.bitnagil.presentation.terms.model.TermsAgreementState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import javax.inject.Inject
+
+@HiltViewModel
+class TermsAgreementViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val submitTermsAgreementUseCase: SubmitTermsAgreementUseCase,
+) : MviViewModel<TermsAgreementState, TermsAgreementSideEffect, TermsAgreementIntent>(
+    initState = TermsAgreementState(),
+    savedStateHandle = savedStateHandle,
+) {
+    override suspend fun SimpleSyntax<TermsAgreementState, TermsAgreementSideEffect>.reduceState(
+        intent: TermsAgreementIntent,
+        state: TermsAgreementState,
+    ): TermsAgreementState? = when (intent) {
+        is TermsAgreementIntent.SetLoading -> {
+            state.copy(isLoading = intent.isLoading)
+        }
+
+        is TermsAgreementIntent.ToggleAllAgreements -> {
+            state.copy(
+                agreedTermsOfService = intent.agreed,
+                agreedPrivacyPolicy = intent.agreed,
+                agreedOverFourteen = intent.agreed,
+            )
+        }
+
+        is TermsAgreementIntent.ToggleTermsOfService -> {
+            state.copy(agreedTermsOfService = intent.agreed)
+        }
+
+        is TermsAgreementIntent.TogglePrivacyPolicy -> {
+            state.copy(agreedPrivacyPolicy = intent.agreed)
+        }
+
+        is TermsAgreementIntent.ToggleOverFourteen -> {
+            state.copy(agreedOverFourteen = intent.agreed)
+        }
+
+        is TermsAgreementIntent.SubmitSuccess -> {
+            sendSideEffect(TermsAgreementSideEffect.NavigateToOnBoarding)
+            state.copy(isLoading = false)
+        }
+
+        is TermsAgreementIntent.SubmitFailure -> {
+            state.copy(isLoading = false)
+        }
+
+        is TermsAgreementIntent.BackButtonClick -> {
+            sendSideEffect(TermsAgreementSideEffect.NavigateToBack)
+            null
+        }
+    }
+
+    fun submitTermsAgreement() {
+        sendIntent(TermsAgreementIntent.SetLoading(true))
+        viewModelScope.launch {
+            val currentState = container.stateFlow.value
+            val agreement = TermsAgreement(
+                agreedToTermsOfService = currentState.agreedTermsOfService,
+                agreedToPrivacyPolicy = currentState.agreedPrivacyPolicy,
+                isOverFourteen = currentState.agreedOverFourteen,
+            )
+
+            submitTermsAgreementUseCase(agreement)
+                .fold(
+                    onSuccess = {
+                        sendIntent(TermsAgreementIntent.SubmitSuccess)
+                    },
+                    onFailure = { error ->
+                        Log.e("TermsAgreement", "Submit failed: ${error.message}")
+                        sendIntent(TermsAgreementIntent.SubmitFailure)
+                    },
+                )
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
@@ -31,27 +31,39 @@ class TermsAgreementViewModel @Inject constructor(
         }
 
         is TermsAgreementIntent.ToggleAllAgreements -> {
-            if (state.isLoading) null
-            else state.copy(
-                agreedTermsOfService = intent.agreed,
-                agreedPrivacyPolicy = intent.agreed,
-                agreedOverFourteen = intent.agreed,
-            )
+            if (state.isLoading) {
+                null
+            } else {
+                state.copy(
+                    agreedTermsOfService = intent.agreed,
+                    agreedPrivacyPolicy = intent.agreed,
+                    agreedOverFourteen = intent.agreed,
+                )
+            }
         }
 
         is TermsAgreementIntent.ToggleTermsOfService -> {
-            if (state.isLoading) null
-            else state.copy(agreedTermsOfService = intent.agreed)
+            if (state.isLoading) {
+                null
+            } else {
+                state.copy(agreedTermsOfService = intent.agreed)
+            }
         }
 
         is TermsAgreementIntent.TogglePrivacyPolicy -> {
-            if (state.isLoading) null
-            else state.copy(agreedPrivacyPolicy = intent.agreed)
+            if (state.isLoading) {
+                null
+            } else {
+                state.copy(agreedPrivacyPolicy = intent.agreed)
+            }
         }
 
         is TermsAgreementIntent.ToggleOverFourteen -> {
-            if (state.isLoading) null
-            else state.copy(agreedOverFourteen = intent.agreed)
+            if (state.isLoading) {
+                null
+            } else {
+                state.copy(agreedOverFourteen = intent.agreed)
+            }
         }
 
         is TermsAgreementIntent.SubmitSuccess -> {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
@@ -31,7 +31,8 @@ class TermsAgreementViewModel @Inject constructor(
         }
 
         is TermsAgreementIntent.ToggleAllAgreements -> {
-            state.copy(
+            if (state.isLoading) null
+            else state.copy(
                 agreedTermsOfService = intent.agreed,
                 agreedPrivacyPolicy = intent.agreed,
                 agreedOverFourteen = intent.agreed,
@@ -39,15 +40,18 @@ class TermsAgreementViewModel @Inject constructor(
         }
 
         is TermsAgreementIntent.ToggleTermsOfService -> {
-            state.copy(agreedTermsOfService = intent.agreed)
+            if (state.isLoading) null
+            else state.copy(agreedTermsOfService = intent.agreed)
         }
 
         is TermsAgreementIntent.TogglePrivacyPolicy -> {
-            state.copy(agreedPrivacyPolicy = intent.agreed)
+            if (state.isLoading) null
+            else state.copy(agreedPrivacyPolicy = intent.agreed)
         }
 
         is TermsAgreementIntent.ToggleOverFourteen -> {
-            state.copy(agreedOverFourteen = intent.agreed)
+            if (state.isLoading) null
+            else state.copy(agreedOverFourteen = intent.agreed)
         }
 
         is TermsAgreementIntent.SubmitSuccess -> {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/component/TermsAgreementItem.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/component/TermsAgreementItem.kt
@@ -1,0 +1,84 @@
+package com.threegap.bitnagil.presentation.terms.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TermsAgreementItem(
+    title: String,
+    isChecked: Boolean,
+    onCheckedChange: () -> Unit,
+    modifier: Modifier = Modifier,
+    showMore: Boolean = false,
+    onClickShowMore: () -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                vertical = 10.dp,
+                horizontal = 20.dp,
+            ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(18.dp),
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable(onClick = onCheckedChange),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = if (isChecked) Color.Black else Color.Gray,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(text = title)
+        }
+
+        if (showMore) {
+            Text(
+                text = "더보기",
+                textDecoration = TextDecoration.Underline,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .clickable(onClick = onClickShowMore),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TermsAgreementItemPreview() {
+    var isChecked by remember { mutableStateOf(false) }
+
+    TermsAgreementItem(
+        title = "(필수) 서비스 이용약관 동의",
+        onCheckedChange = {
+            isChecked = !isChecked
+        },
+        isChecked = isChecked,
+        showMore = true,
+    )
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementIntent.kt
@@ -1,0 +1,21 @@
+package com.threegap.bitnagil.presentation.terms.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
+
+sealed class TermsAgreementIntent : MviIntent {
+    data class SetLoading(val isLoading: Boolean) : TermsAgreementIntent()
+
+    data class ToggleAllAgreements(val agreed: Boolean) : TermsAgreementIntent()
+
+    data class ToggleTermsOfService(val agreed: Boolean) : TermsAgreementIntent()
+
+    data class TogglePrivacyPolicy(val agreed: Boolean) : TermsAgreementIntent()
+
+    data class ToggleOverFourteen(val agreed: Boolean) : TermsAgreementIntent()
+
+    data object SubmitSuccess : TermsAgreementIntent()
+
+    data object SubmitFailure : TermsAgreementIntent()
+
+    data object BackButtonClick : TermsAgreementIntent()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementSideEffect.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.presentation.terms.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
+
+sealed interface TermsAgreementSideEffect : MviSideEffect {
+    data object NavigateToOnBoarding : TermsAgreementSideEffect
+
+    data object NavigateToBack : TermsAgreementSideEffect
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementState.kt
@@ -1,0 +1,15 @@
+package com.threegap.bitnagil.presentation.terms.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviState
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TermsAgreementState(
+    val isLoading: Boolean = false,
+    val agreedTermsOfService: Boolean = false,
+    val agreedPrivacyPolicy: Boolean = false,
+    val agreedOverFourteen: Boolean = false,
+) : MviState {
+    val isAllAgreed: Boolean
+        get() = agreedTermsOfService && agreedPrivacyPolicy && agreedOverFourteen
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementState.kt
@@ -12,4 +12,7 @@ data class TermsAgreementState(
 ) : MviState {
     val isAllAgreed: Boolean
         get() = agreedTermsOfService && agreedPrivacyPolicy && agreedOverFourteen
+
+    val submitEnabled: Boolean
+        get() = !isLoading && isAllAgreed
 }


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
서비스 이용을 위한 약관동의 화면 구현

## Related issue
- closed #28 

## Screenshot 📸
- N/A

## Work Description
- 약관동의 화면 구현
- 약관동의 제출 api 연동

## To Reviewers 📢
- 약관동의 화면 구현했습니다! (ui 고도화는 추후 디자인시스템 작업이 완료되면 진행하겠습니다!)
- 약관 동의목록을 제출하기 위한 위한 api도 같이 연동했습니다~!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이용약관 동의 화면이 추가되어 서비스 이용약관, 개인정보처리방침, 만 14세 이상 여부에 대한 동의를 받을 수 있습니다.
  * 전체 동의 및 개별 동의 항목, "더보기" 기능, 시작 버튼 활성화 기능이 제공됩니다.
  * 로그인 후 게스트 사용자는 약관 동의 화면으로 자동 이동합니다.
  * 약관 동의 정보 제출 및 검증 로직이 도입되어 동의 내용을 서버에 안전하게 전송합니다.

* **버그 수정**
  * 로그인 후 약관 동의 화면으로 이동하는 네비게이션 명칭이 일관성 있게 변경되었습니다.

* **UI/UX**
  * 체크박스, 토글, 시각적 안내 등 약관 동의 항목별 UI가 개선되었습니다.

* **기타**
  * 약관 동의 상태 관리 및 네비게이션 흐름이 개선되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->