### PR TITLE
[Feature/#35] 이용약관 화면 구현

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
@@ -4,11 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.threegap.bitnagil.presentation.home.HomeScreen
 import com.threegap.bitnagil.presentation.intro.IntroScreenContainer
 import com.threegap.bitnagil.presentation.login.LoginScreenContainer
 import com.threegap.bitnagil.presentation.splash.SplashScreenContainer
 import com.threegap.bitnagil.presentation.terms.TermsAgreementScreenContainer
+import com.threegap.bitnagil.presentation.webview.BitnagilWebViewScreen
 
 @Composable
 fun MainNavHost(
@@ -42,6 +44,22 @@ fun MainNavHost(
 
         composable<Route.TermsAgreement> {
             TermsAgreementScreenContainer(
+                navigateToTermsOfService = {
+                    navigator.navController.navigate(
+                        Route.WebView(
+                            title = "약관 동의",
+                            url = "https://wooded-damselfly-4cc.notion.site/22fa2c11608680668ed7e3227b69812a",
+                        ),
+                    )
+                },
+                navigateToPrivacyPolicy = {
+                    navigator.navController.navigate(
+                        Route.WebView(
+                            title = "약관 동의",
+                            url = "https://wooded-damselfly-4cc.notion.site/22fa2c11608680668ed7e3227b69812a",
+                        ),
+                    )
+                },
                 navigateToOnBoarding = { },
                 navigateToBack = { navigator.navController.popBackStack() },
             )
@@ -49,6 +67,15 @@ fun MainNavHost(
 
         composable<Route.Home> {
             HomeScreen()
+        }
+
+        composable<Route.WebView> {
+            val webViewRoute = it.toRoute<Route.WebView>()
+            BitnagilWebViewScreen(
+                title = webViewRoute.title,
+                url = webViewRoute.url,
+                onBackClick = { navigator.navController.popBackStack() },
+            )
         }
     }
 }

--- a/app/src/main/java/com/threegap/bitnagil/Route.kt
+++ b/app/src/main/java/com/threegap/bitnagil/Route.kt
@@ -18,4 +18,10 @@ sealed interface Route {
 
     @Serializable
     data object Home : Route
+
+    @Serializable
+    data class WebView(
+        val title: String,
+        val url: String,
+    ) : Route
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
@@ -36,6 +36,8 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun TermsAgreementScreenContainer(
+    navigateToTermsOfService: () -> Unit,
+    navigateToPrivacyPolicy: () -> Unit,
     navigateToOnBoarding: () -> Unit,
     navigateToBack: () -> Unit,
     viewmodel: TermsAgreementViewModel = hiltViewModel(),
@@ -44,6 +46,14 @@ fun TermsAgreementScreenContainer(
 
     viewmodel.collectSideEffect { sideEffect ->
         when (sideEffect) {
+            is TermsAgreementSideEffect.NavigateToPrivacyPolicy -> {
+                navigateToPrivacyPolicy()
+            }
+
+            is TermsAgreementSideEffect.NavigateToTermsOfService -> {
+                navigateToTermsOfService()
+            }
+
             is TermsAgreementSideEffect.NavigateToOnBoarding -> {
                 navigateToOnBoarding()
             }
@@ -68,6 +78,12 @@ fun TermsAgreementScreenContainer(
         onToggleOverFourteen = {
             viewmodel.sendIntent(TermsAgreementIntent.ToggleOverFourteen(it))
         },
+        onShowTermsOfService = {
+            viewmodel.sendIntent(TermsAgreementIntent.ShowTermsOfService)
+        },
+        onShowPrivacyPolicy = {
+            viewmodel.sendIntent(TermsAgreementIntent.ShowPrivacyPolicy)
+        },
         onStartButtonClick = {
             viewmodel.submitTermsAgreement()
         },
@@ -84,6 +100,8 @@ private fun TermsAgreementScreen(
     onToggleTermsOfService: (Boolean) -> Unit,
     onTogglePrivacyPolicy: (Boolean) -> Unit,
     onToggleOverFourteen: (Boolean) -> Unit,
+    onShowTermsOfService: () -> Unit,
+    onShowPrivacyPolicy: () -> Unit,
     onStartButtonClick: () -> Unit,
     onBackButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -162,6 +180,7 @@ private fun TermsAgreementScreen(
                 onCheckedChange = { onToggleTermsOfService(!uiState.agreedTermsOfService) },
                 isChecked = uiState.agreedTermsOfService,
                 showMore = true,
+                onClickShowMore = onShowTermsOfService,
             )
 
             TermsAgreementItem(
@@ -169,6 +188,7 @@ private fun TermsAgreementScreen(
                 onCheckedChange = { onTogglePrivacyPolicy(!uiState.agreedPrivacyPolicy) },
                 isChecked = uiState.agreedPrivacyPolicy,
                 showMore = true,
+                onClickShowMore = onShowPrivacyPolicy,
             )
 
             TermsAgreementItem(
@@ -202,6 +222,8 @@ private fun TermsAgreementScreenPreview() {
         onToggleTermsOfService = {},
         onTogglePrivacyPolicy = {},
         onToggleOverFourteen = {},
+        onShowTermsOfService = {},
+        onShowPrivacyPolicy = {},
         onStartButtonClick = {},
         onBackButtonClick = {},
     )

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
@@ -66,6 +66,16 @@ class TermsAgreementViewModel @Inject constructor(
             }
         }
 
+        is TermsAgreementIntent.ShowTermsOfService -> {
+            sendSideEffect(TermsAgreementSideEffect.NavigateToTermsOfService)
+            null
+        }
+
+        is TermsAgreementIntent.ShowPrivacyPolicy -> {
+            sendSideEffect(TermsAgreementSideEffect.NavigateToPrivacyPolicy)
+            null
+        }
+
         is TermsAgreementIntent.SubmitSuccess -> {
             sendSideEffect(TermsAgreementSideEffect.NavigateToOnBoarding)
             state.copy(isLoading = false)

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementIntent.kt
@@ -4,18 +4,13 @@ import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
 
 sealed class TermsAgreementIntent : MviIntent {
     data class SetLoading(val isLoading: Boolean) : TermsAgreementIntent()
-
     data class ToggleAllAgreements(val agreed: Boolean) : TermsAgreementIntent()
-
     data class ToggleTermsOfService(val agreed: Boolean) : TermsAgreementIntent()
-
     data class TogglePrivacyPolicy(val agreed: Boolean) : TermsAgreementIntent()
-
     data class ToggleOverFourteen(val agreed: Boolean) : TermsAgreementIntent()
-
+    data object ShowTermsOfService : TermsAgreementIntent()
+    data object ShowPrivacyPolicy : TermsAgreementIntent()
     data object SubmitSuccess : TermsAgreementIntent()
-
     data object SubmitFailure : TermsAgreementIntent()
-
     data object BackButtonClick : TermsAgreementIntent()
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/model/TermsAgreementSideEffect.kt
@@ -3,7 +3,8 @@ package com.threegap.bitnagil.presentation.terms.model
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
 
 sealed interface TermsAgreementSideEffect : MviSideEffect {
+    data object NavigateToTermsOfService : TermsAgreementSideEffect
+    data object NavigateToPrivacyPolicy : TermsAgreementSideEffect
     data object NavigateToOnBoarding : TermsAgreementSideEffect
-
     data object NavigateToBack : TermsAgreementSideEffect
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/webview/BitnagilWebViewScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/webview/BitnagilWebViewScreen.kt
@@ -1,0 +1,124 @@
+package com.threegap.bitnagil.presentation.webview
+
+import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+
+@Composable
+fun BitnagilWebViewScreen(
+    title: String,
+    url: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val webView = remember {
+        WebView(context).apply {
+            webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                ): Boolean {
+                    val requestUrl = request?.url?.toString()
+                    return requestUrl?.contains("notion.site") != true
+                }
+            }
+
+            settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                allowFileAccess = false
+                allowContentAccess = false
+            }
+
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+        }
+    }
+
+    DisposableEffect(webView) {
+        onDispose {
+            webView.destroy()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BitnagilTheme.colors.white),
+    ) {
+        Box(
+            modifier = Modifier
+                .height(54.dp)
+                .fillMaxWidth(),
+        ) {
+            // todo: 아이콘 수정하기
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 4.dp)
+                    // todo: 리플효과 제거하기
+                    .clickable(
+                        onClick = onBackClick,
+                    )
+                    .size(36.dp),
+            )
+
+            Text(
+                text = title,
+                color = BitnagilTheme.colors.coolGray10,
+                style = BitnagilTheme.typography.title3SemiBold,
+                modifier = Modifier
+                    .align(Alignment.Center),
+            )
+        }
+
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { webView },
+            update = { view ->
+                if (view.url != url) {
+                    view.loadUrl(url)
+                }
+            },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitnagilWebViewScreenPreview() {
+    BitnagilWebViewScreen(
+        title = "약관 동의",
+        url = "",
+        onBackClick = {},
+    )
+}


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
이용약관 화면을 구현합니다.

## Related issue
- closed #35

## Screenshot 📸

https://github.com/user-attachments/assets/f481cee3-5ee7-4ce0-9d02-89a397804613

## Work Description
- 이용약관 화면 구현(웹뷰 연결)

## To Reviewers 📢
- 이용약관 화면에 대한 웹뷰를 연결했습니다..!
- 실제 약관링크가 아직 없어서 임시 노션링크를 사용했는데, 추후 링크를 전달받으면 변경하겠습니다!
- 각 약관별로 화면을 분리하는것보단, 하나의 화면를 사용하고 url를 전달받는것이 중복되는 화면을 줄일 수 있다고 생각되어 url를 넘겨받는 방식으로 구현해봤습니다요!
- 놓친 부분, 이상한점, 궁금한점이 있다면 리뷰 남겨주세요!