### PR TITLE
[Feature/#39] 마이페이지/설정 화면 구현

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
@@ -42,8 +42,8 @@ fun MyPageScreenContainer(
         state = state,
         onClickSetting = navigateToSetting,
         onClickNotice = navigateToNotice,
-        onClickResetOnBoarding = navigateToQnA,
-        onClickQnA = navigateToOnBoarding,
+        onClickResetOnBoarding = navigateToOnBoarding,
+        onClickQnA = navigateToQnA,
     )
 }
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
@@ -59,12 +59,12 @@ private fun MyPageScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(color = BitnagilTheme.colors.white),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Box(
             modifier = Modifier
                 .height(54.dp)
-                .fillMaxWidth()
+                .fillMaxWidth(),
         ) {
             Text(
                 "마이페이지",
@@ -89,13 +89,13 @@ private fun MyPageScreen(
             contentDescription = null,
             modifier = Modifier
                 .size(80.dp)
-                .clip(shape = CircleShape)
+                .clip(shape = CircleShape),
         )
 
         Text(
             state.name,
             style = BitnagilTheme.typography.title3SemiBold,
-            modifier = Modifier.padding(top = 12.dp)
+            modifier = Modifier.padding(top = 12.dp),
         )
 
         Spacer(modifier = Modifier.height(28.dp))
@@ -109,7 +109,7 @@ private fun MyPageScreen(
                 .height(48.dp)
                 .clickable(onClick = onClickResetOnBoarding)
                 .padding(start = 16.dp, end = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 "내 목표 재설정",
@@ -121,7 +121,7 @@ private fun MyPageScreen(
                 modifier = Modifier
                     .padding(end = 10.dp)
                     .size(36.dp)
-                    .background(BitnagilTheme.colors.black)
+                    .background(BitnagilTheme.colors.black),
             )
         }
 
@@ -130,7 +130,7 @@ private fun MyPageScreen(
                 .height(48.dp)
                 .clickable(onClick = onClickNotice)
                 .padding(start = 16.dp, end = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 "공지사항",
@@ -142,7 +142,7 @@ private fun MyPageScreen(
                 modifier = Modifier
                     .padding(end = 10.dp)
                     .size(36.dp)
-                    .background(BitnagilTheme.colors.black)
+                    .background(BitnagilTheme.colors.black),
             )
         }
 
@@ -151,7 +151,7 @@ private fun MyPageScreen(
                 .height(48.dp)
                 .clickable(onClick = onClickQnA)
                 .padding(start = 16.dp, end = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 "자주 묻는 질문",
@@ -163,7 +163,7 @@ private fun MyPageScreen(
                 modifier = Modifier
                     .padding(end = 10.dp)
                     .size(36.dp)
-                    .background(BitnagilTheme.colors.black)
+                    .background(BitnagilTheme.colors.black),
             )
         }
     }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageScreen.kt
@@ -1,0 +1,184 @@
+package com.threegap.bitnagil.presentation.mypage
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.presentation.mypage.model.MyPageState
+
+@Composable
+fun MyPageScreenContainer(
+    myPageViewModel: MyPageViewModel = hiltViewModel(),
+    navigateToSetting: () -> Unit,
+    navigateToNotice: () -> Unit,
+    navigateToQnA: () -> Unit,
+    navigateToOnBoarding: () -> Unit,
+) {
+    val state by myPageViewModel.stateFlow.collectAsState()
+
+    MyPageScreen(
+        state = state,
+        onClickSetting = navigateToSetting,
+        onClickNotice = navigateToNotice,
+        onClickResetOnBoarding = navigateToQnA,
+        onClickQnA = navigateToOnBoarding,
+    )
+}
+
+@Composable
+private fun MyPageScreen(
+    state: MyPageState,
+    onClickSetting: () -> Unit,
+    onClickNotice: () -> Unit,
+    onClickResetOnBoarding: () -> Unit,
+    onClickQnA: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = BitnagilTheme.colors.white),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .height(54.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                "마이페이지",
+                modifier = Modifier.align(Alignment.Center),
+                style = BitnagilTheme.typography.title3SemiBold,
+            )
+
+            Box(
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .size(36.dp)
+                    .background(BitnagilTheme.colors.black)
+                    .align(Alignment.CenterEnd)
+                    .clickable(onClick = onClickSetting),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Image(
+            painter = ColorPainter(BitnagilTheme.colors.coolGray98),
+            contentDescription = null,
+            modifier = Modifier
+                .size(80.dp)
+                .clip(shape = CircleShape)
+        )
+
+        Text(
+            state.name,
+            style = BitnagilTheme.typography.title3SemiBold,
+            modifier = Modifier.padding(top = 12.dp)
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        HorizontalDivider(modifier = Modifier.height(6.dp), thickness = 6.dp, color = BitnagilTheme.colors.coolGray98)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier
+                .height(48.dp)
+                .clickable(onClick = onClickResetOnBoarding)
+                .padding(start = 16.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "내 목표 재설정",
+                style = BitnagilTheme.typography.body1Regular,
+                modifier = Modifier.weight(1f),
+            )
+
+            Box(
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .size(36.dp)
+                    .background(BitnagilTheme.colors.black)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .height(48.dp)
+                .clickable(onClick = onClickNotice)
+                .padding(start = 16.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "공지사항",
+                style = BitnagilTheme.typography.body1Regular,
+                modifier = Modifier.weight(1f),
+            )
+
+            Box(
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .size(36.dp)
+                    .background(BitnagilTheme.colors.black)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .height(48.dp)
+                .clickable(onClick = onClickQnA)
+                .padding(start = 16.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "자주 묻는 질문",
+                style = BitnagilTheme.typography.body1Regular,
+                modifier = Modifier.weight(1f),
+            )
+
+            Box(
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .size(36.dp)
+                    .background(BitnagilTheme.colors.black)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MyPageScreenPreview() {
+    BitnagilTheme {
+        MyPageScreen(
+            state = MyPageState(name = "이름", profileUrl = ""),
+            onClickSetting = { },
+            onClickNotice = { },
+            onClickResetOnBoarding = { },
+            onClickQnA = { },
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
@@ -16,7 +16,7 @@ class MyPageViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : MviViewModel<MyPageState, MyPageSideEffect, MyPageIntent>(
     MyPageState.Init,
-    savedStateHandle
+    savedStateHandle,
 ) {
     init {
         loadMyPageInfo()
@@ -30,13 +30,13 @@ class MyPageViewModel @Inject constructor(
 
     override suspend fun SimpleSyntax<MyPageState, MyPageSideEffect>.reduceState(
         intent: MyPageIntent,
-        state: MyPageState
+        state: MyPageState,
     ): MyPageState {
-        when(intent) {
+        when (intent) {
             is MyPageIntent.LoadMyPageSuccess -> {
                 return state.copy(
                     name = intent.name,
-                    profileUrl = intent.profileUrl
+                    profileUrl = intent.profileUrl,
                 )
             }
         }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
@@ -1,0 +1,44 @@
+package com.threegap.bitnagil.presentation.mypage
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
+import com.threegap.bitnagil.presentation.mypage.model.MyPageIntent
+import com.threegap.bitnagil.presentation.mypage.model.MyPageSideEffect
+import com.threegap.bitnagil.presentation.mypage.model.MyPageState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import javax.inject.Inject
+
+@HiltViewModel
+class MyPageViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : MviViewModel<MyPageState, MyPageSideEffect, MyPageIntent>(
+    MyPageState.Init,
+    savedStateHandle
+) {
+    init {
+        loadMyPageInfo()
+    }
+
+    private fun loadMyPageInfo() {
+        viewModelScope.launch {
+            sendIntent(MyPageIntent.LoadMyPageSuccess(name = "이름", profileUrl = "profileUrl"))
+        }
+    }
+
+    override suspend fun SimpleSyntax<MyPageState, MyPageSideEffect>.reduceState(
+        intent: MyPageIntent,
+        state: MyPageState
+    ): MyPageState {
+        when(intent) {
+            is MyPageIntent.LoadMyPageSuccess -> {
+                return state.copy(
+                    name = intent.name,
+                    profileUrl = intent.profileUrl
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageIntent.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.presentation.mypage.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
+
+sealed class MyPageIntent: MviIntent {
+    data class LoadMyPageSuccess(val name: String, val profileUrl: String) : MyPageIntent()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageIntent.kt
@@ -2,6 +2,6 @@ package com.threegap.bitnagil.presentation.mypage.model
 
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
 
-sealed class MyPageIntent: MviIntent {
+sealed class MyPageIntent : MviIntent {
     data class LoadMyPageSuccess(val name: String, val profileUrl: String) : MyPageIntent()
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageSideEffect.kt
@@ -1,0 +1,5 @@
+package com.threegap.bitnagil.presentation.mypage.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
+
+sealed class MyPageSideEffect: MviSideEffect

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageSideEffect.kt
@@ -2,4 +2,4 @@ package com.threegap.bitnagil.presentation.mypage.model
 
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
 
-sealed class MyPageSideEffect: MviSideEffect
+sealed class MyPageSideEffect : MviSideEffect

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/model/MyPageState.kt
@@ -1,0 +1,14 @@
+package com.threegap.bitnagil.presentation.mypage.model
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviState
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class MyPageState(
+    val name: String,
+    val profileUrl: String,
+) : MviState {
+    companion object {
+        val Init = MyPageState(name = "", profileUrl = "")
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
@@ -1,0 +1,198 @@
+package com.threegap.bitnagil.presentation.setting
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.presentation.setting.component.atom.settingtitle.SettingTitle
+import com.threegap.bitnagil.presentation.setting.component.atom.toggleswitch.ToggleSwitch
+import com.threegap.bitnagil.presentation.setting.component.block.settingrowbutton.SettingRowButton
+import com.threegap.bitnagil.presentation.setting.model.mvi.SettingState
+
+@Composable
+fun SettingScreenContainer(
+    viewModel: SettingViewModel = hiltViewModel()
+) {
+    val state by viewModel.stateFlow.collectAsState()
+
+    SettingScreen(
+        state = state,
+        toggleServiceAlarm = viewModel::toggleServiceAlarm,
+        togglePushAlarm = viewModel::togglePushAlarm,
+        onClickUpdate = {}
+    )
+}
+
+@Composable
+private fun SettingScreen(
+    state: SettingState,
+    toggleServiceAlarm: () -> Unit,
+    togglePushAlarm: () -> Unit,
+    onClickUpdate: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = BitnagilTheme.colors.white)
+    ) {
+        Box(
+            modifier = Modifier
+                .height(54.dp)
+                .fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(start = 10.dp)
+                    .size(36.dp)
+                    .background(BitnagilTheme.colors.black)
+                    .align(Alignment.CenterStart)
+                    .clickable {
+
+                    },
+            )
+
+            Text(
+                "설정",
+                modifier = Modifier.align(Alignment.Center),
+                style = BitnagilTheme.typography.title3SemiBold,
+            )
+
+        }
+
+        val scrollState = rememberScrollState()
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(scrollState)
+        ) {
+            Spacer(modifier = Modifier.height(32.dp))
+
+            SettingTitle("알림")
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("서비스 이용 알림", style = BitnagilTheme.typography.body1Regular)
+                ToggleSwitch(checked = state.useServiceAlarm, onCheckedChange = { toggleServiceAlarm() })
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("푸시알림", style = BitnagilTheme.typography.body1Regular)
+                ToggleSwitch(checked = state.usePushAlarm, onCheckedChange = { togglePushAlarm() })
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            HorizontalDivider(modifier = Modifier.height(6.dp), thickness = 6.dp, color = BitnagilTheme.colors.coolGray98)
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            SettingTitle("정보")
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row {
+                    Text("버전 ", style = BitnagilTheme.typography.body1Regular)
+                    Text(state.version, style = BitnagilTheme.typography.body1SemiBold)
+                }
+                if (state.version == state.latestVersion) {
+                    Text(
+                        "최신",
+                        modifier = Modifier
+                            .background(
+                                color = BitnagilTheme.colors.coolGray98,
+                                shape = RoundedCornerShape(4.dp),
+                            )
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                        style = BitnagilTheme.typography.button2.copy(color = BitnagilTheme.colors.coolGray70),
+                    )
+                } else {
+                    Text(
+                        "업데이트",
+                        modifier = Modifier
+                            .background(
+                                color = BitnagilTheme.colors.lightBlue200,
+                                shape = RoundedCornerShape(4.dp),
+                            )
+                            .clickable(onClick = onClickUpdate)
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                        style = BitnagilTheme.typography.button2.copy(color = BitnagilTheme.colors.navy500),
+                    )
+                }
+
+            }
+
+            SettingRowButton(text = "서비스 이용약관", onClick = {})
+
+            SettingRowButton(text = "개인정보 처리방침", onClick = {})
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            HorizontalDivider(modifier = Modifier.height(6.dp), thickness = 6.dp, color = BitnagilTheme.colors.coolGray98)
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            SettingTitle("계정")
+
+            SettingRowButton(text = "로그아웃", onClick = {})
+
+            SettingRowButton(text = "탈퇴하기", onClick = {})
+        }
+    }
+}
+
+@Composable
+@Preview
+fun SettingScreenPreview() {
+    SettingScreen(
+        state = SettingState(
+            useServiceAlarm = true,
+            usePushAlarm = false,
+            version = "1.0.1",
+            latestVersion = "1.0.0",
+        ),
+        toggleServiceAlarm = {},
+        togglePushAlarm = {},
+        onClickUpdate = {}
+    )
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
@@ -33,7 +33,7 @@ import com.threegap.bitnagil.presentation.setting.model.mvi.SettingState
 
 @Composable
 fun SettingScreenContainer(
-    viewModel: SettingViewModel = hiltViewModel()
+    viewModel: SettingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsState()
 
@@ -41,7 +41,7 @@ fun SettingScreenContainer(
         state = state,
         toggleServiceAlarm = viewModel::toggleServiceAlarm,
         togglePushAlarm = viewModel::togglePushAlarm,
-        onClickUpdate = {}
+        onClickUpdate = {},
     )
 }
 
@@ -55,12 +55,12 @@ private fun SettingScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = BitnagilTheme.colors.white)
+            .background(color = BitnagilTheme.colors.white),
     ) {
         Box(
             modifier = Modifier
                 .height(54.dp)
-                .fillMaxWidth()
+                .fillMaxWidth(),
         ) {
             Box(
                 modifier = Modifier
@@ -69,7 +69,6 @@ private fun SettingScreen(
                     .background(BitnagilTheme.colors.black)
                     .align(Alignment.CenterStart)
                     .clickable {
-
                     },
             )
 
@@ -78,14 +77,13 @@ private fun SettingScreen(
                 modifier = Modifier.align(Alignment.Center),
                 style = BitnagilTheme.typography.title3SemiBold,
             )
-
         }
 
         val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
                 .weight(1f)
-                .verticalScroll(scrollState)
+                .verticalScroll(scrollState),
         ) {
             Spacer(modifier = Modifier.height(32.dp))
 
@@ -97,7 +95,7 @@ private fun SettingScreen(
                     .height(48.dp)
                     .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("서비스 이용 알림", style = BitnagilTheme.typography.body1Regular)
                 ToggleSwitch(checked = state.useServiceAlarm, onCheckedChange = { toggleServiceAlarm() })
@@ -109,7 +107,7 @@ private fun SettingScreen(
                     .height(48.dp)
                     .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("푸시알림", style = BitnagilTheme.typography.body1Regular)
                 ToggleSwitch(checked = state.usePushAlarm, onCheckedChange = { togglePushAlarm() })
@@ -129,7 +127,7 @@ private fun SettingScreen(
                     .height(48.dp)
                     .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row {
                     Text("버전 ", style = BitnagilTheme.typography.body1Regular)
@@ -159,7 +157,6 @@ private fun SettingScreen(
                         style = BitnagilTheme.typography.button2.copy(color = BitnagilTheme.colors.navy500),
                     )
                 }
-
             }
 
             SettingRowButton(text = "서비스 이용약관", onClick = {})
@@ -193,6 +190,6 @@ fun SettingScreenPreview() {
         ),
         toggleServiceAlarm = {},
         togglePushAlarm = {},
-        onClickUpdate = {}
+        onClickUpdate = {},
     )
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
@@ -1,0 +1,68 @@
+package com.threegap.bitnagil.presentation.setting
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
+import com.threegap.bitnagil.presentation.setting.model.mvi.SettingIntent
+import com.threegap.bitnagil.presentation.setting.model.mvi.SettingSideEffect
+import com.threegap.bitnagil.presentation.setting.model.mvi.SettingState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : MviViewModel<SettingState, SettingSideEffect, SettingIntent>(
+    initState = SettingState.Init,
+    savedStateHandle = savedStateHandle,
+) {
+    private var setServiceAlarmJob: Job? = null
+    private var setPushAlarmJob: Job? = null
+
+    override suspend fun SimpleSyntax<SettingState, SettingSideEffect>.reduceState(
+        intent: SettingIntent,
+        state: SettingState
+    ): SettingState {
+        when(intent) {
+            is SettingIntent.LoadSettingSuccess -> {
+                return state.copy(
+                    useServiceAlarm = intent.useServiceAlarm,
+                    usePushAlarm = intent.usePushAlarm,
+                    version = intent.version,
+                    latestVersion = intent.latestVersion,
+                )
+            }
+            SettingIntent.TogglePushAlarm -> {
+                return state.copy(
+                    usePushAlarm = !state.usePushAlarm
+                )
+            }
+            SettingIntent.ToggleServiceAlarm -> {
+                return state.copy(
+                    useServiceAlarm = !state.useServiceAlarm
+                )
+            }
+        }
+    }
+
+    fun toggleServiceAlarm() {
+        sendIntent(SettingIntent.ToggleServiceAlarm)
+        setServiceAlarmJob?.cancel()
+        setServiceAlarmJob = viewModelScope.launch {
+            delay(1000L)
+
+        }
+    }
+
+    fun togglePushAlarm() {
+        sendIntent(SettingIntent.TogglePushAlarm)
+        setPushAlarmJob?.cancel()
+        setPushAlarmJob = viewModelScope.launch {
+            delay(1000L)
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
@@ -25,9 +25,9 @@ class SettingViewModel @Inject constructor(
 
     override suspend fun SimpleSyntax<SettingState, SettingSideEffect>.reduceState(
         intent: SettingIntent,
-        state: SettingState
+        state: SettingState,
     ): SettingState {
-        when(intent) {
+        when (intent) {
             is SettingIntent.LoadSettingSuccess -> {
                 return state.copy(
                     useServiceAlarm = intent.useServiceAlarm,
@@ -38,12 +38,12 @@ class SettingViewModel @Inject constructor(
             }
             SettingIntent.TogglePushAlarm -> {
                 return state.copy(
-                    usePushAlarm = !state.usePushAlarm
+                    usePushAlarm = !state.usePushAlarm,
                 )
             }
             SettingIntent.ToggleServiceAlarm -> {
                 return state.copy(
-                    useServiceAlarm = !state.useServiceAlarm
+                    useServiceAlarm = !state.useServiceAlarm,
                 )
             }
         }
@@ -54,7 +54,6 @@ class SettingViewModel @Inject constructor(
         setServiceAlarmJob?.cancel()
         setServiceAlarmJob = viewModelScope.launch {
             delay(1000L)
-
         }
     }
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/settingtitle/SettingTitle.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/settingtitle/SettingTitle.kt
@@ -15,6 +15,6 @@ fun SettingTitle(
     Text(
         title,
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 3.dp),
-        style = BitnagilTheme.typography.caption1SemiBold.copy(color = BitnagilTheme.colors.coolGray50)
+        style = BitnagilTheme.typography.caption1SemiBold.copy(color = BitnagilTheme.colors.coolGray50),
     )
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/settingtitle/SettingTitle.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/settingtitle/SettingTitle.kt
@@ -1,0 +1,20 @@
+package com.threegap.bitnagil.presentation.setting.component.atom.settingtitle
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+
+@Composable
+fun SettingTitle(
+    title: String,
+) {
+    Text(
+        title,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 3.dp),
+        style = BitnagilTheme.typography.caption1SemiBold.copy(color = BitnagilTheme.colors.coolGray50)
+    )
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/Preview.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/Preview.kt
@@ -1,0 +1,33 @@
+package com.threegap.bitnagil.presentation.setting.component.atom.toggleswitch
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview(showBackground = true)
+@Composable
+fun ManualSwitchPreview() {
+    var isChecked by remember { mutableStateOf(true) }
+
+    Column(
+        modifier = Modifier.padding(16.dp).width(100.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // 켜진 상태
+        ToggleSwitch (
+            checked = isChecked,
+            onCheckedChange = { checked ->
+                isChecked = checked
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/Preview.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/Preview.kt
@@ -20,14 +20,14 @@ fun ManualSwitchPreview() {
 
     Column(
         modifier = Modifier.padding(16.dp).width(100.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // 켜진 상태
-        ToggleSwitch (
+        ToggleSwitch(
             checked = isChecked,
             onCheckedChange = { checked ->
                 isChecked = checked
-            }
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/ToggleSwitch.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/ToggleSwitch.kt
@@ -5,9 +5,14 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -18,7 +23,7 @@ import com.threegap.bitnagil.designsystem.BitnagilTheme
 @Composable
 fun ToggleSwitch(
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    onCheckedChange: (Boolean) -> Unit,
 ) {
     val trackWidth = 44.dp
     val trackHeight = 24.dp
@@ -27,12 +32,12 @@ fun ToggleSwitch(
 
     val thumbOffset by animateDpAsState(
         targetValue = if (checked) trackWidth - thumbDiameter - padding else padding,
-        animationSpec = tween(durationMillis = 200)
+        animationSpec = tween(durationMillis = 200),
     )
 
     val trackColor by animateColorAsState(
         targetValue = if (checked) BitnagilTheme.colors.navy500 else BitnagilTheme.colors.coolGray95,
-        animationSpec = tween(durationMillis = 200)
+        animationSpec = tween(durationMillis = 200),
     )
 
     Box(
@@ -41,19 +46,19 @@ fun ToggleSwitch(
             .height(trackHeight)
             .clip(CircleShape)
             .background(trackColor)
-            .clickable { onCheckedChange(!checked) }
+            .clickable { onCheckedChange(!checked) },
     ) {
         Box(
             modifier = Modifier
-                .offset{
+                .offset {
                     IntOffset(
                         x = thumbOffset.toPx().toInt(),
-                        y = 0
+                        y = 0,
                     )
                 }
                 .size(thumbDiameter)
                 .align(Alignment.CenterStart)
-                .background(BitnagilTheme.colors.white, CircleShape)
+                .background(BitnagilTheme.colors.white, CircleShape),
         )
     }
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/ToggleSwitch.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/atom/toggleswitch/ToggleSwitch.kt
@@ -1,0 +1,59 @@
+package com.threegap.bitnagil.presentation.setting.component.atom.toggleswitch
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+
+@Composable
+fun ToggleSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    val trackWidth = 44.dp
+    val trackHeight = 24.dp
+    val thumbDiameter = 20.dp
+    val padding = (trackHeight - thumbDiameter) / 2
+
+    val thumbOffset by animateDpAsState(
+        targetValue = if (checked) trackWidth - thumbDiameter - padding else padding,
+        animationSpec = tween(durationMillis = 200)
+    )
+
+    val trackColor by animateColorAsState(
+        targetValue = if (checked) BitnagilTheme.colors.navy500 else BitnagilTheme.colors.coolGray95,
+        animationSpec = tween(durationMillis = 200)
+    )
+
+    Box(
+        modifier = Modifier
+            .width(trackWidth)
+            .height(trackHeight)
+            .clip(CircleShape)
+            .background(trackColor)
+            .clickable { onCheckedChange(!checked) }
+    ) {
+        Box(
+            modifier = Modifier
+                .offset{
+                    IntOffset(
+                        x = thumbOffset.toPx().toInt(),
+                        y = 0
+                    )
+                }
+                .size(thumbDiameter)
+                .align(Alignment.CenterStart)
+                .background(BitnagilTheme.colors.white, CircleShape)
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/block/settingrowbutton/SettingRowButton.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/block/settingrowbutton/SettingRowButton.kt
@@ -1,0 +1,42 @@
+package com.threegap.bitnagil.presentation.setting.component.block.settingrowbutton
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+
+@Composable
+fun SettingRowButton(
+    onClick: () -> Unit,
+    text: String,
+) {
+    Row(
+        modifier = Modifier
+            .height(48.dp)
+            .clickable(onClick = onClick)
+            .padding(start = 16.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text,
+            style = BitnagilTheme.typography.body1Regular,
+            modifier = Modifier.weight(1f),
+        )
+
+        Box(
+            modifier = Modifier
+                .padding(end = 10.dp)
+                .size(36.dp)
+                .background(BitnagilTheme.colors.black)
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/block/settingrowbutton/SettingRowButton.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/component/block/settingrowbutton/SettingRowButton.kt
@@ -24,7 +24,7 @@ fun SettingRowButton(
             .height(48.dp)
             .clickable(onClick = onClick)
             .padding(start = 16.dp, end = 4.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text,
@@ -36,7 +36,7 @@ fun SettingRowButton(
             modifier = Modifier
                 .padding(end = 10.dp)
                 .size(36.dp)
-                .background(BitnagilTheme.colors.black)
+                .background(BitnagilTheme.colors.black),
         )
     }
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingIntent.kt
@@ -1,0 +1,15 @@
+package com.threegap.bitnagil.presentation.setting.model.mvi
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
+
+sealed class SettingIntent : MviIntent {
+    data class LoadSettingSuccess(
+        val useServiceAlarm: Boolean,
+        val usePushAlarm: Boolean,
+        val version: String,
+        val latestVersion: String,
+    ) : SettingIntent()
+
+    data object ToggleServiceAlarm : SettingIntent()
+    data object TogglePushAlarm : SettingIntent()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingSideEffect.kt
@@ -1,0 +1,5 @@
+package com.threegap.bitnagil.presentation.setting.model.mvi
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
+
+sealed class SettingSideEffect : MviSideEffect

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/model/mvi/SettingState.kt
@@ -1,0 +1,21 @@
+package com.threegap.bitnagil.presentation.setting.model.mvi
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviState
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SettingState(
+    val useServiceAlarm: Boolean,
+    val usePushAlarm: Boolean,
+    val version: String,
+    val latestVersion: String,
+) : MviState {
+    companion object {
+        val Init = SettingState(
+            useServiceAlarm = false,
+            usePushAlarm = false,
+            version = "",
+            latestVersion = "",
+        )
+    }
+}


### PR DESCRIPTION
# [ PR Content ]
마이페이지, 설정 화면을 구현합니다.

## Related issue
- closed #39 

## Screenshot 📸

<img src = "https://github.com/user-attachments/assets/5766b605-e3c5-4e9c-bbf4-79b1bf8036fd" width="24%">
<img src = "https://github.com/user-attachments/assets/beab66a4-14e8-413c-a313-41ddc2c92e6c" width="24%">


## Work Description
- 마이페이지/설정 화면 구현

## To Reviewers 📢
- 검은색 부분은 아이콘 영역으로 토요일 해커톤때 대체될 예정입니다!
- 질문사항 있다면 코멘트 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지 화면이 추가되어 사용자 이름, 프로필 이미지, 목표 재설정, 공지사항, FAQ, 설정 진입 등이 가능합니다.
  * 설정 화면이 도입되어 서비스 알림, 푸시 알림 토글, 앱 버전 확인 및 업데이트, 약관·정책 확인, 로그아웃, 탈퇴 기능을 제공합니다.
  * 토글 스위치, 설정 행 버튼, 설정 섹션 타이틀 등 UI 컴포넌트가 새롭게 추가되었습니다.

* **스타일**
  * 일관된 테마와 스타일이 전체 마이페이지 및 설정 화면에 적용되었습니다.

* **문서화**
  * 각 화면 및 주요 UI 컴포넌트에 대한 미리보기(Preview)가 제공되어 개발 시 UI를 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->