### PR TITLE
[Feature/#43] 감정 구슬 화면 구현

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
@@ -4,6 +4,8 @@ import com.threegap.bitnagil.data.auth.datasource.AuthLocalDataSource
 import com.threegap.bitnagil.data.auth.datasource.AuthRemoteDataSource
 import com.threegap.bitnagil.data.auth.datasourceimpl.AuthLocalDataSourceImpl
 import com.threegap.bitnagil.data.auth.datasourceimpl.AuthRemoteDataSourceImpl
+import com.threegap.bitnagil.data.emotion.datasource.EmotionDataSource
+import com.threegap.bitnagil.data.emotion.datasourceImpl.EmotionDataSourceImpl
 import com.threegap.bitnagil.data.onboarding.datasource.OnBoardingDataSource
 import com.threegap.bitnagil.data.onboarding.datasourceImpl.OnBoardingDataSourceImpl
 import com.threegap.bitnagil.data.writeroutine.datasource.WriteRoutineDataSource
@@ -29,6 +31,10 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindOnBoardingDataSource(onBoardingDataSourceImpl: OnBoardingDataSourceImpl): OnBoardingDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindEmotionDataSource(emotionDataSourceImpl: EmotionDataSourceImpl): EmotionDataSource
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
@@ -1,9 +1,11 @@
 package com.threegap.bitnagil.di.data
 
 import com.threegap.bitnagil.data.auth.repositoryimpl.AuthRepositoryImpl
+import com.threegap.bitnagil.data.emotion.repositoryImpl.EmotionRepositoryImpl
 import com.threegap.bitnagil.data.onboarding.repositoryImpl.OnBoardingRepositoryImpl
 import com.threegap.bitnagil.data.writeroutine.repositoryImpl.WriteRoutineRepositoryImpl
 import com.threegap.bitnagil.domain.auth.repository.AuthRepository
+import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
 import com.threegap.bitnagil.domain.onboarding.repository.OnBoardingRepository
 import com.threegap.bitnagil.domain.writeroutine.repository.WriteRoutineRepository
 import dagger.Binds
@@ -23,6 +25,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindOnBoardingRepository(onBoardingRepositoryImpl: OnBoardingRepositoryImpl): OnBoardingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindEmotionRepository(emotionRepositoryImpl: EmotionRepositoryImpl): EmotionRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.threegap.bitnagil.di.data
 
 import com.threegap.bitnagil.data.auth.service.AuthService
+import com.threegap.bitnagil.data.emotion.service.EmotionService
 import com.threegap.bitnagil.data.onboarding.service.OnBoardingService
 import com.threegap.bitnagil.data.writeroutine.service.WriteRoutineService
 import com.threegap.bitnagil.di.core.Auth
@@ -26,6 +27,11 @@ object ServiceModule {
     @Singleton
     fun providerOnBoardingService(@Auth retrofit: Retrofit): OnBoardingService =
         retrofit.create(OnBoardingService::class.java)
+
+    @Provides
+    @Singleton
+    fun providerEmotionService(@Auth retrofit: Retrofit): EmotionService =
+        retrofit.create(EmotionService::class.java)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/datasource/EmotionDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/datasource/EmotionDataSource.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.data.emotion.datasource
+
+import com.threegap.bitnagil.data.emotion.model.response.GetEmotionsResponse
+import com.threegap.bitnagil.data.emotion.model.response.RegisterEmotionResponse
+
+interface EmotionDataSource {
+    suspend fun getEmotions(): Result<GetEmotionsResponse>
+    suspend fun registerEmotion(emotion: String): Result<RegisterEmotionResponse>
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/datasourceImpl/EmotionDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/datasourceImpl/EmotionDataSourceImpl.kt
@@ -9,7 +9,7 @@ import com.threegap.bitnagil.data.emotion.service.EmotionService
 import javax.inject.Inject
 
 class EmotionDataSourceImpl @Inject constructor(
-    private val emotionService: EmotionService
+    private val emotionService: EmotionService,
 ) : EmotionDataSource {
     override suspend fun getEmotions(): Result<GetEmotionsResponse> {
         return safeApiCall {

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/datasourceImpl/EmotionDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/datasourceImpl/EmotionDataSourceImpl.kt
@@ -1,0 +1,26 @@
+package com.threegap.bitnagil.data.emotion.datasourceImpl
+
+import com.threegap.bitnagil.data.common.safeApiCall
+import com.threegap.bitnagil.data.emotion.datasource.EmotionDataSource
+import com.threegap.bitnagil.data.emotion.model.request.RegisterEmotionRequest
+import com.threegap.bitnagil.data.emotion.model.response.GetEmotionsResponse
+import com.threegap.bitnagil.data.emotion.model.response.RegisterEmotionResponse
+import com.threegap.bitnagil.data.emotion.service.EmotionService
+import javax.inject.Inject
+
+class EmotionDataSourceImpl @Inject constructor(
+    private val emotionService: EmotionService
+) : EmotionDataSource {
+    override suspend fun getEmotions(): Result<GetEmotionsResponse> {
+        return safeApiCall {
+            emotionService.getEmotions()
+        }
+    }
+
+    override suspend fun registerEmotion(emotion: String): Result<RegisterEmotionResponse> {
+        val registerEmotionRequest = RegisterEmotionRequest(emotionMarbleType = emotion)
+        return safeApiCall {
+            emotionService.postEmotions(registerEmotionRequest)
+        }
+    }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedRoutineDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedRoutineDto.kt
@@ -12,5 +12,5 @@ data class EmotionRecommendedRoutineDto(
     @SerialName("routineDescription")
     val routineDescription: String,
     @SerialName("recommendedSubRoutines")
-    val recommendedSubRoutines: List<EmotionRecommendedSubRoutineDto>
+    val recommendedSubRoutines: List<EmotionRecommendedSubRoutineDto>,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedRoutineDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedRoutineDto.kt
@@ -1,0 +1,16 @@
+package com.threegap.bitnagil.data.emotion.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EmotionRecommendedRoutineDto(
+    @SerialName("recommendedRoutineId")
+    val recommendedRoutineId: Int,
+    @SerialName("recommendedRoutineName")
+    val recommendedRoutineName: String,
+    @SerialName("routineDescription")
+    val routineDescription: String,
+    @SerialName("recommendedSubRoutines")
+    val recommendedSubRoutines: List<EmotionRecommendedSubRoutineDto>
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedSubRoutineDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/dto/EmotionRecommendedSubRoutineDto.kt
@@ -1,0 +1,12 @@
+package com.threegap.bitnagil.data.emotion.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EmotionRecommendedSubRoutineDto(
+    @SerialName("recommendedSubRoutineId")
+    val recommendedSubRoutineId: Int,
+    @SerialName("recommendedSubRoutineName")
+    val recommendedSubRoutineName: String,
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/request/RegisterEmotionRequest.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/request/RegisterEmotionRequest.kt
@@ -1,0 +1,10 @@
+package com.threegap.bitnagil.data.emotion.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterEmotionRequest(
+    @SerialName("emotionMarbleType")
+    val emotionMarbleType: String
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/request/RegisterEmotionRequest.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/request/RegisterEmotionRequest.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RegisterEmotionRequest(
     @SerialName("emotionMarbleType")
-    val emotionMarbleType: String
+    val emotionMarbleType: String,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/GetEmotionsResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/GetEmotionsResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GetEmotionsResponse(
     @SerialName("emotionMarbleTypes")
-    val emotionMarbleTypes: List<String>
+    val emotionMarbleTypes: List<String>,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/GetEmotionsResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/GetEmotionsResponse.kt
@@ -1,0 +1,10 @@
+package com.threegap.bitnagil.data.emotion.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetEmotionsResponse(
+    @SerialName("emotionMarbleTypes")
+    val emotionMarbleTypes: List<String>
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/RegisterEmotionResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/RegisterEmotionResponse.kt
@@ -1,0 +1,11 @@
+package com.threegap.bitnagil.data.emotion.model.response
+
+import com.threegap.bitnagil.data.emotion.model.dto.EmotionRecommendedRoutineDto
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterEmotionResponse(
+    @SerialName("recommendedRoutines")
+    val recommendedRoutines: List<EmotionRecommendedRoutineDto>
+)

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/RegisterEmotionResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/model/response/RegisterEmotionResponse.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RegisterEmotionResponse(
     @SerialName("recommendedRoutines")
-    val recommendedRoutines: List<EmotionRecommendedRoutineDto>
+    val recommendedRoutines: List<EmotionRecommendedRoutineDto>,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/repositoryImpl/EmotionRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/repositoryImpl/EmotionRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package com.threegap.bitnagil.data.emotion.repositoryImpl
+
+import com.threegap.bitnagil.data.emotion.datasource.EmotionDataSource
+import com.threegap.bitnagil.domain.emotion.model.Emotion
+import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
+import javax.inject.Inject
+
+class EmotionRepositoryImpl @Inject constructor(
+    private val emotionDataSource: EmotionDataSource
+) : EmotionRepository {
+    override suspend fun getEmotions(): Result<List<Emotion>> {
+        return emotionDataSource.getEmotions().map { response ->
+            response.emotionMarbleTypes.mapNotNull {
+                when(it) {
+                    "CALM" -> Emotion.CALM
+                    "VITALITY" -> Emotion.VITALITY
+                    "LETHARGY" -> Emotion.LETHARGY
+                    "ANXIETY" -> Emotion.ANXIETY
+                    "SATISFACTION" -> Emotion.SATISFACTION
+                    "FATIGUE" -> Emotion.FATIGUE
+                    else -> null
+                }
+            }
+        }
+    }
+
+    override suspend fun registerEmotion(emotion: Emotion): Result<Unit> {
+        val selectedEmotion = when(emotion) {
+            Emotion.CALM -> "CALM"
+            Emotion.VITALITY -> "VITALITY"
+            Emotion.LETHARGY -> "LETHARGY"
+            Emotion.ANXIETY -> "ANXIETY"
+            Emotion.SATISFACTION -> "SATISFACTION"
+            Emotion.FATIGUE -> "FATIGUE"
+        }
+
+        return emotionDataSource.registerEmotion(selectedEmotion).map { _ -> }
+    }
+
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/repositoryImpl/EmotionRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/repositoryImpl/EmotionRepositoryImpl.kt
@@ -6,12 +6,12 @@ import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
 import javax.inject.Inject
 
 class EmotionRepositoryImpl @Inject constructor(
-    private val emotionDataSource: EmotionDataSource
+    private val emotionDataSource: EmotionDataSource,
 ) : EmotionRepository {
     override suspend fun getEmotions(): Result<List<Emotion>> {
         return emotionDataSource.getEmotions().map { response ->
             response.emotionMarbleTypes.mapNotNull {
-                when(it) {
+                when (it) {
                     "CALM" -> Emotion.CALM
                     "VITALITY" -> Emotion.VITALITY
                     "LETHARGY" -> Emotion.LETHARGY
@@ -25,7 +25,7 @@ class EmotionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun registerEmotion(emotion: Emotion): Result<Unit> {
-        val selectedEmotion = when(emotion) {
+        val selectedEmotion = when (emotion) {
             Emotion.CALM -> "CALM"
             Emotion.VITALITY -> "VITALITY"
             Emotion.LETHARGY -> "LETHARGY"
@@ -36,5 +36,4 @@ class EmotionRepositoryImpl @Inject constructor(
 
         return emotionDataSource.registerEmotion(selectedEmotion).map { _ -> }
     }
-
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
@@ -14,6 +14,6 @@ interface EmotionService {
 
     @POST("/api/v1/emotion-marbles")
     suspend fun postEmotions(
-        @Body request: RegisterEmotionRequest
+        @Body request: RegisterEmotionRequest,
     ): BaseResponse<RegisterEmotionResponse>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
@@ -1,0 +1,19 @@
+package com.threegap.bitnagil.data.emotion.service
+
+import com.threegap.bitnagil.data.emotion.model.request.RegisterEmotionRequest
+import com.threegap.bitnagil.data.emotion.model.response.GetEmotionsResponse
+import com.threegap.bitnagil.data.emotion.model.response.RegisterEmotionResponse
+import com.threegap.bitnagil.network.model.BaseResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface EmotionService {
+    @GET("/api/v1/emotion-marbles")
+    suspend fun getEmotions(): BaseResponse<GetEmotionsResponse>
+
+    @POST("/api/v1/emotion-marbles")
+    suspend fun postEmotions(
+        @Body request: RegisterEmotionRequest
+    ): BaseResponse<RegisterEmotionResponse>
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/model/Emotion.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/model/Emotion.kt
@@ -1,0 +1,10 @@
+package com.threegap.bitnagil.domain.emotion.model
+
+enum class Emotion {
+    CALM,
+    VITALITY,
+    LETHARGY,
+    ANXIETY,
+    SATISFACTION,
+    FATIGUE,
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/repository/EmotionRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/repository/EmotionRepository.kt
@@ -1,0 +1,8 @@
+package com.threegap.bitnagil.domain.emotion.repository
+
+import com.threegap.bitnagil.domain.emotion.model.Emotion
+
+interface EmotionRepository {
+    suspend fun getEmotions(): Result<List<Emotion>>
+    suspend fun registerEmotion(emotion: Emotion): Result<Unit>
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/GetEmotionsUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/GetEmotionsUseCase.kt
@@ -1,0 +1,13 @@
+package com.threegap.bitnagil.domain.emotion.usecase
+
+import com.threegap.bitnagil.domain.emotion.model.Emotion
+import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
+import javax.inject.Inject
+
+class GetEmotionsUseCase @Inject constructor(
+    private val emotionRepository: EmotionRepository
+) {
+    suspend operator fun invoke() : Result<List<Emotion>> {
+        return emotionRepository.getEmotions()
+    }
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/GetEmotionsUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/GetEmotionsUseCase.kt
@@ -5,9 +5,9 @@ import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
 import javax.inject.Inject
 
 class GetEmotionsUseCase @Inject constructor(
-    private val emotionRepository: EmotionRepository
+    private val emotionRepository: EmotionRepository,
 ) {
-    suspend operator fun invoke() : Result<List<Emotion>> {
+    suspend operator fun invoke(): Result<List<Emotion>> {
         return emotionRepository.getEmotions()
     }
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/RegisterEmotionUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/RegisterEmotionUseCase.kt
@@ -5,9 +5,9 @@ import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
 import javax.inject.Inject
 
 class RegisterEmotionUseCase @Inject constructor(
-    private val emotionRepository: EmotionRepository
+    private val emotionRepository: EmotionRepository,
 ) {
-    suspend operator fun invoke(emotion: Emotion) : Result<Unit> {
+    suspend operator fun invoke(emotion: Emotion): Result<Unit> {
         return emotionRepository.registerEmotion(emotion)
     }
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/RegisterEmotionUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/emotion/usecase/RegisterEmotionUseCase.kt
@@ -1,0 +1,13 @@
+package com.threegap.bitnagil.domain.emotion.usecase
+
+import com.threegap.bitnagil.domain.emotion.model.Emotion
+import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
+import javax.inject.Inject
+
+class RegisterEmotionUseCase @Inject constructor(
+    private val emotionRepository: EmotionRepository
+) {
+    suspend operator fun invoke(emotion: Emotion) : Result<Unit> {
+        return emotionRepository.registerEmotion(emotion)
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
@@ -63,7 +63,7 @@ private fun EmotionScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(color = BitnagilTheme.colors.white),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Box(
             modifier = Modifier
@@ -86,7 +86,11 @@ private fun EmotionScreen(
 
         Spacer(modifier = Modifier.height(6.dp))
 
-        Text("감정구슬을 등록하면 루틴을 추천받아요!", style = BitnagilTheme.typography.subtitle1Regular.copy(color = BitnagilTheme.colors.navy300), textAlign = TextAlign.Center)
+        Text(
+            "감정구슬을 등록하면 루틴을 추천받아요!",
+            style = BitnagilTheme.typography.subtitle1Regular.copy(color = BitnagilTheme.colors.navy300),
+            textAlign = TextAlign.Center,
+        )
 
         Spacer(modifier = Modifier.height(64.dp))
 
@@ -94,18 +98,18 @@ private fun EmotionScreen(
             columns = GridCells.Fixed(3),
             modifier = Modifier.padding(horizontal = 40.dp).widthIn(300.dp),
             horizontalArrangement = Arrangement.spacedBy(32.dp),
-            verticalArrangement = Arrangement.spacedBy(32.dp)
+            verticalArrangement = Arrangement.spacedBy(32.dp),
         ) {
             items(state.emotions) { emotion ->
                 Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Image(
                         painter = painterResource(id = emotion.imageResourceId),
                         contentDescription = null,
                         modifier = Modifier.size(72.dp).clickable {
                             onClickEmotion(emotion)
-                        }
+                        },
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(emotion.emotionName, style = BitnagilTheme.typography.body1Regular.copy(color = BitnagilTheme.colors.coolGray20))
@@ -125,7 +129,7 @@ fun MyPageScreenPreview() {
                 isLoading = false,
             ),
             onClickEmotion = { _ -> },
-            onClickPreviousButton = {}
+            onClickPreviousButton = {},
         )
     }
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
@@ -1,0 +1,131 @@
+package com.threegap.bitnagil.presentation.emotion
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.presentation.common.flow.collectAsEffect
+import com.threegap.bitnagil.presentation.emotion.model.Emotion
+import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionSideEffect
+import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionState
+
+@Composable
+fun EmotionScreenContainer(
+    viewModel: EmotionViewModel = hiltViewModel(),
+    navigateToBack: () -> Unit,
+) {
+    val state by viewModel.stateFlow.collectAsState()
+
+    viewModel.sideEffectFlow.collectAsEffect { sideEffect ->
+        when (sideEffect) {
+            EmotionSideEffect.NavigateToBack -> navigateToBack()
+        }
+    }
+
+    EmotionScreen(
+        state = state,
+        onClickPreviousButton = navigateToBack,
+        onClickEmotion = viewModel::selectEmotion,
+    )
+}
+
+@Composable
+private fun EmotionScreen(
+    state: EmotionState,
+    onClickPreviousButton: () -> Unit,
+    onClickEmotion: (Emotion) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = BitnagilTheme.colors.white),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .height(54.dp)
+                .fillMaxWidth(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(start = 2.dp)
+                    .size(48.dp)
+                    .background(BitnagilTheme.colors.black)
+                    .align(Alignment.CenterStart)
+                    .clickable(onClick = onClickPreviousButton),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text("오늘의 감정구슬을 골라보세요", style = BitnagilTheme.typography.title2Bold.copy(color = BitnagilTheme.colors.navy500), textAlign = TextAlign.Center)
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text("감정구슬을 등록하면 루틴을 추천받아요!", style = BitnagilTheme.typography.subtitle1Regular.copy(color = BitnagilTheme.colors.navy300), textAlign = TextAlign.Center)
+
+        Spacer(modifier = Modifier.height(64.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            modifier = Modifier.padding(horizontal = 40.dp).widthIn(300.dp),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            items(state.emotions) { emotion ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        painter = painterResource(id = emotion.imageResourceId),
+                        contentDescription = null,
+                        modifier = Modifier.size(72.dp).clickable {
+                            onClickEmotion(emotion)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(emotion.emotionName, style = BitnagilTheme.typography.body1Regular.copy(color = BitnagilTheme.colors.coolGray20))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MyPageScreenPreview() {
+    BitnagilTheme {
+        EmotionScreen(
+            state = EmotionState(
+                emotions = Emotion.entries,
+                isLoading = false,
+            ),
+            onClickEmotion = { _ -> },
+            onClickPreviousButton = {}
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionViewModel.kt
@@ -1,0 +1,73 @@
+package com.threegap.bitnagil.presentation.emotion
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.domain.emotion.usecase.GetEmotionsUseCase
+import com.threegap.bitnagil.domain.emotion.usecase.RegisterEmotionUseCase
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
+import com.threegap.bitnagil.presentation.emotion.model.Emotion
+import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionIntent
+import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionSideEffect
+import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import javax.inject.Inject
+
+@HiltViewModel
+class EmotionViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getEmotionsUseCase: GetEmotionsUseCase,
+    private val registerEmotionUseCase: RegisterEmotionUseCase,
+) : MviViewModel<EmotionState, EmotionSideEffect, EmotionIntent>(
+    savedStateHandle = savedStateHandle,
+    initState = EmotionState.Init
+) {
+    init {
+        loadEmotions()
+    }
+
+    private fun loadEmotions() {
+        viewModelScope.launch {
+            getEmotionsUseCase().fold(
+                onSuccess = { emotions ->
+                    sendIntent(
+                        EmotionIntent.EmotionListLoadSuccess(emotions = emotions.map { Emotion.fromDomain(it) })
+                    )
+                },
+                onFailure = {
+                    // todo 실패 케이스 정의되면 처리
+                },
+            )
+        }
+    }
+
+    override suspend fun SimpleSyntax<EmotionState, EmotionSideEffect>.reduceState(intent: EmotionIntent, state: EmotionState): EmotionState? {
+        when(intent) {
+            is EmotionIntent.EmotionListLoadSuccess -> {
+                return state.copy(
+                    emotions = intent.emotions,
+                    isLoading = false,
+                )
+            }
+            EmotionIntent.RegisterEmotionSuccess -> {
+                postSideEffect(EmotionSideEffect.NavigateToBack)
+                return null
+            }
+        }
+    }
+
+    fun selectEmotion(emotion: Emotion) {
+        viewModelScope.launch {
+            registerEmotionUseCase(emotion = emotion.toDomain()).fold(
+                onSuccess = {
+                    sendIntent(EmotionIntent.RegisterEmotionSuccess)
+                },
+                onFailure = {
+                    // todo 실패 케이스 정의되면 처리
+                }
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/Emotion.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/Emotion.kt
@@ -1,0 +1,41 @@
+package com.threegap.bitnagil.presentation.emotion.model
+
+import com.threegap.bitnagil.domain.emotion.model.Emotion as DomainEmotion
+
+enum class Emotion(
+    val emotionName: String,
+    val imageResourceId: Int,
+) {
+    // todo - 이미지 리소스 전달받은 후 해당 이미지로 수정
+    CALM(emotionName = "평온함", imageResourceId = android.R.drawable.ic_menu_report_image),
+    VITALITY(emotionName = "활기참", imageResourceId = android.R.drawable.ic_menu_report_image),
+    LETHARGY(emotionName = "무기력함", imageResourceId = android.R.drawable.ic_menu_report_image),
+    ANXIETY(emotionName = "불안함", imageResourceId = android.R.drawable.ic_menu_report_image),
+    SATISFACTION(emotionName = "만족함", imageResourceId = android.R.drawable.ic_menu_report_image),
+    FATIGUE(emotionName = "피로함", imageResourceId = android.R.drawable.ic_menu_report_image),
+    ;
+
+    companion object {
+        fun fromDomain(domain: DomainEmotion): Emotion {
+            return when (domain) {
+                DomainEmotion.CALM -> CALM
+                DomainEmotion.VITALITY -> VITALITY
+                DomainEmotion.LETHARGY -> LETHARGY
+                DomainEmotion.ANXIETY -> ANXIETY
+                DomainEmotion.SATISFACTION -> SATISFACTION
+                DomainEmotion.FATIGUE -> FATIGUE
+            }
+        }
+    }
+
+    fun toDomain(): DomainEmotion {
+        return when (this) {
+            CALM -> DomainEmotion.CALM
+            VITALITY -> DomainEmotion.VITALITY
+            LETHARGY -> DomainEmotion.LETHARGY
+            ANXIETY -> DomainEmotion.ANXIETY
+            SATISFACTION -> DomainEmotion.SATISFACTION
+            FATIGUE -> DomainEmotion.FATIGUE
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionIntent.kt
@@ -1,0 +1,9 @@
+package com.threegap.bitnagil.presentation.emotion.model.mvi
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
+import com.threegap.bitnagil.presentation.emotion.model.Emotion
+
+sealed class EmotionIntent: MviIntent {
+    data class EmotionListLoadSuccess(val emotions: List<Emotion>) : EmotionIntent()
+    data object RegisterEmotionSuccess : EmotionIntent()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionIntent.kt
@@ -3,7 +3,8 @@ package com.threegap.bitnagil.presentation.emotion.model.mvi
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviIntent
 import com.threegap.bitnagil.presentation.emotion.model.Emotion
 
-sealed class EmotionIntent: MviIntent {
+sealed class EmotionIntent : MviIntent {
     data class EmotionListLoadSuccess(val emotions: List<Emotion>) : EmotionIntent()
     data object RegisterEmotionSuccess : EmotionIntent()
+    data object RegisterEmotionLoading : EmotionIntent()
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionSideEffect.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.presentation.emotion.model.mvi
+
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviSideEffect
+
+sealed class EmotionSideEffect : MviSideEffect {
+    data object NavigateToBack : EmotionSideEffect()
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/model/mvi/EmotionState.kt
@@ -1,0 +1,20 @@
+package com.threegap.bitnagil.presentation.emotion.model.mvi
+
+import androidx.compose.runtime.Immutable
+import com.threegap.bitnagil.presentation.common.mviviewmodel.MviState
+import com.threegap.bitnagil.presentation.emotion.model.Emotion
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@Immutable
+data class EmotionState(
+    val emotions: List<Emotion>,
+    val isLoading: Boolean,
+) : MviState {
+    companion object {
+        val Init = EmotionState(
+            emotions = emptyList(),
+            isLoading = true,
+        )
+    }
+}


### PR DESCRIPTION
# [ PR Content ]
감정 구슬 화면을 구현합니다.

## Related issue
- closed #43

## Screenshot 📸
<img src = "https://github.com/user-attachments/assets/4e514de2-f110-4252-b92d-30ada54136f2" width="24%">


## Work Description
- 감정 구슬 화면 및 감정 조회/감정 등록 API를 연결했습니다

## To Reviewers 📢
- 사진상의 이미지 영역들은 전부 해커톤때 교체 예정입니다!
- 질문사항 혹은 제가 실수한 부분이 있다면 코멘트 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 감정 선택 및 등록을 위한 새로운 감정 선택 화면이 추가되었습니다.
  * 감정 목록을 불러오고, 감정 등록 시 추천 루틴 정보를 제공하는 기능이 도입되었습니다.
  * 감정 관련 상태 관리 및 화면 전환(뒤로가기 등)이 지원됩니다.

* **UI**
  * 감정 아이콘과 이름이 그리드 형태로 표시되는 감정 선택 UI가 추가되었습니다.

* **기타**
  * 감정, 추천 루틴 등 관련 데이터 모델과 비즈니스 로직이 새롭게 구현되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->