### PR TITLE
[Feature/#59] 마이페이지 유저 프로필 API 연동

### DIFF
--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
@@ -8,6 +8,7 @@ import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface EmotionService {
@@ -19,8 +20,8 @@ interface EmotionService {
         @Body request: RegisterEmotionRequest,
     ): BaseResponse<RegisterEmotionResponse>
 
-    @GET("/api/v1/emotion-marbles/me")
+    @GET("/api/v1/emotion-marbles/{searchDate}")
     suspend fun getMyEmotionMarble(
-        @Query("searchDate") date: String,
+        @Path("searchDate") date: String,
     ): BaseResponse<MyEmotionResponseDto>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/emotion/service/EmotionService.kt
@@ -9,7 +9,6 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 interface EmotionService {
     @GET("/api/v1/emotion-marbles")

--- a/data/src/main/java/com/threegap/bitnagil/data/user/service/UserService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/user/service/UserService.kt
@@ -5,6 +5,6 @@ import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.GET
 
 interface UserService {
-    @GET("/api/v1/users/nickname")
+    @GET("/api/v1/users/infos")
     suspend fun fetchUserProfile(): BaseResponse<UserProfileResponseDto>
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
@@ -2,6 +2,7 @@ package com.threegap.bitnagil.presentation.mypage
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.threegap.bitnagil.domain.user.usecase.FetchUserProfileUseCase
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
 import com.threegap.bitnagil.presentation.mypage.model.MyPageIntent
 import com.threegap.bitnagil.presentation.mypage.model.MyPageSideEffect
@@ -14,6 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val fetchUserProfileUseCase: FetchUserProfileUseCase,
 ) : MviViewModel<MyPageState, MyPageSideEffect, MyPageIntent>(
     MyPageState.Init,
     savedStateHandle,
@@ -24,7 +26,18 @@ class MyPageViewModel @Inject constructor(
 
     private fun loadMyPageInfo() {
         viewModelScope.launch {
-            sendIntent(MyPageIntent.LoadMyPageSuccess(name = "이름", profileUrl = "profileUrl"))
+            fetchUserProfileUseCase().fold(
+                onSuccess = {
+                    sendIntent(
+                        MyPageIntent.LoadMyPageSuccess(
+                            name = it.nickname,
+                            profileUrl = "profileUrl",
+                        ),
+                    )
+                },
+                onFailure = {
+                },
+            )
         }
     }
 


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
마이페이지 화면 유저 프로필 API를 연동했습니다.
추가로 변경사항이 있는 API 엔드포인트(유저프로필, 감정구슬)를 수정했습니다.

## Related issue
- closed #59 

## Screenshot 📸
- N/A

## Work Description
- 마이페이지 유저 프로필 조회 API 연동
- 유저프로필, 감정구슬 조회 API 엔드포인드 수정

## To Reviewers 📢
- 간단한 작업이라 없슴다~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지 정보 로드시 사용자 프로필을 동적으로 불러오도록 개선되었습니다.

* **버그 수정**
  * 감정 구슬 조회 시 날짜 파라미터가 쿼리에서 경로 파라미터로 변경되어 요청 방식이 수정되었습니다.
  * 사용자 프로필 조회 엔드포인트가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->