### PR TITLE
[Feature/#63] 루틴 등록/수정시 홈 화면 리프레시 기능 구현

### DIFF
--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/model/WriteRoutineEvent.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/model/WriteRoutineEvent.kt
@@ -1,0 +1,6 @@
+package com.threegap.bitnagil.domain.writeroutine.model
+
+sealed interface WriteRoutineEvent {
+    data object AddRoutine : WriteRoutineEvent
+    data class EditRoutine(val routineId: String) : WriteRoutineEvent
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/repository/WriteRoutineRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/repository/WriteRoutineRepository.kt
@@ -3,6 +3,8 @@ package com.threegap.bitnagil.domain.writeroutine.repository
 import com.threegap.bitnagil.domain.writeroutine.model.RepeatDay
 import com.threegap.bitnagil.domain.writeroutine.model.SubRoutineDiff
 import com.threegap.bitnagil.domain.writeroutine.model.Time
+import com.threegap.bitnagil.domain.writeroutine.model.WriteRoutineEvent
+import kotlinx.coroutines.flow.Flow
 
 interface WriteRoutineRepository {
     suspend fun registerRoutine(
@@ -19,4 +21,6 @@ interface WriteRoutineRepository {
         startTime: Time,
         subRoutines: List<SubRoutineDiff>,
     ): Result<Unit>
+
+    suspend fun getWriteRoutineEventFlow(): Flow<WriteRoutineEvent>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/GetWriteRoutineEventFlowUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/GetWriteRoutineEventFlowUseCase.kt
@@ -1,0 +1,12 @@
+package com.threegap.bitnagil.domain.writeroutine.usecase
+
+import com.threegap.bitnagil.domain.writeroutine.model.WriteRoutineEvent
+import com.threegap.bitnagil.domain.writeroutine.repository.WriteRoutineRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetWriteRoutineEventFlowUseCase @Inject constructor(
+    private val repository: WriteRoutineRepository
+){
+    suspend operator fun invoke() : Flow<WriteRoutineEvent> = repository.getWriteRoutineEventFlow()
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/GetWriteRoutineEventFlowUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/GetWriteRoutineEventFlowUseCase.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetWriteRoutineEventFlowUseCase @Inject constructor(
-    private val repository: WriteRoutineRepository
-){
-    suspend operator fun invoke() : Flow<WriteRoutineEvent> = repository.getWriteRoutineEventFlow()
+    private val repository: WriteRoutineRepository,
+) {
+    suspend operator fun invoke(): Flow<WriteRoutineEvent> = repository.getWriteRoutineEventFlow()
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
@@ -44,7 +44,7 @@ class HomeViewModel @Inject constructor(
     private val routineCompletionUseCase: RoutineCompletionUseCase,
     private val deleteRoutineUseCase: DeleteRoutineUseCase,
     private val deleteRoutineByDayUseCase: DeleteRoutineByDayUseCase,
-    private val getWriteRoutineEventFlowUseCase: GetWriteRoutineEventFlowUseCase
+    private val getWriteRoutineEventFlowUseCase: GetWriteRoutineEventFlowUseCase,
 ) : MviViewModel<HomeState, HomeSideEffect, HomeIntent>(
     initState = HomeState(),
     savedStateHandle = savedStateHandle,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.threegap.bitnagil.domain.routine.usecase.DeleteRoutineUseCase
 import com.threegap.bitnagil.domain.routine.usecase.FetchWeeklyRoutinesUseCase
 import com.threegap.bitnagil.domain.routine.usecase.RoutineCompletionUseCase
 import com.threegap.bitnagil.domain.user.usecase.FetchUserProfileUseCase
+import com.threegap.bitnagil.domain.writeroutine.usecase.GetWriteRoutineEventFlowUseCase
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
 import com.threegap.bitnagil.presentation.home.model.EmotionBallType
 import com.threegap.bitnagil.presentation.home.model.HomeIntent
@@ -43,6 +44,7 @@ class HomeViewModel @Inject constructor(
     private val routineCompletionUseCase: RoutineCompletionUseCase,
     private val deleteRoutineUseCase: DeleteRoutineUseCase,
     private val deleteRoutineByDayUseCase: DeleteRoutineByDayUseCase,
+    private val getWriteRoutineEventFlowUseCase: GetWriteRoutineEventFlowUseCase
 ) : MviViewModel<HomeState, HomeSideEffect, HomeIntent>(
     initState = HomeState(),
     savedStateHandle = savedStateHandle,
@@ -52,6 +54,7 @@ class HomeViewModel @Inject constructor(
     private val routineSyncTrigger = MutableSharedFlow<LocalDate>()
 
     init {
+        observeWriteRoutineEvent()
         observeWeekChanges()
         observeRoutineUpdates()
         fetchWeeklyRoutines(container.stateFlow.value.currentWeeks)
@@ -226,6 +229,14 @@ class HomeViewModel @Inject constructor(
             }
         }
         return newState
+    }
+
+    private fun observeWriteRoutineEvent() {
+        viewModelScope.launch {
+            getWriteRoutineEventFlowUseCase().collect {
+                fetchWeeklyRoutines(container.stateFlow.value.currentWeeks)
+            }
+        }
     }
 
     @OptIn(FlowPreview::class)


### PR DESCRIPTION
# [ PR Content ]
추천 루틴을 등록하거나 루틴을 등록/삭제했을 때 홈 화면에서 바로 리프래시하여 사용자가 갱신된 루틴 목록을 볼 수 있도록 합니다.

## Related issue
- closed #63 

## Screenshot 📸

https://github.com/user-attachments/assets/c639e2ea-6945-4282-be64-ccb72a4c2fb4


## Work Description
- 루틴 작성/루틴 수정이 성공한 경우 홈 화면 리프레시가 수행됩니다

## To Reviewers 📢
- 루틴 작성/수정 이벤트의 경우 WriteRoutineRepository 내부에서 처리하고 있는데 이에 대한 이유는 아래와 같습니다!
  - 해당 데이터가 런타임에만 저장되는 데이터이기 때문에 dataSource에 넣는게 살짝 어색하다고 느껴졌습니다
  - dataSource에 배치할 경우 data layer 내 사용을 위한 클래스를 별도로 생성해야 하는데 domain 클래스와 완전히 동일할 것으로 생각되어 불필요하다고 느껴졌습니다
  - 다만 이건 제 생각이어서 다른 의견 있으시다면 공유 부탁드립니다!
- 영상 녹화하면서 알게 된 내용인데, 링크 수정 이후 바텀 시트와 현재 표시되는 루틴 명이 다른 부분이 있어서 추후 링크 수정 누르면 바텀 시트가 그냥 종료되로록 하는게 좋을 것 같습니다!
- 위 내용 외 다른 궁금한 부분 있으시다면 코멘트 부탁드려요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 루틴 등록 및 수정 시 이벤트가 발생하여, 루틴 추가 또는 수정 후 홈 화면의 주간 루틴 목록이 자동으로 새로고침됩니다.
  * 루틴 관련 이벤트를 실시간으로 감지할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->