### PR TITLE
[Fix/#76] 추천 루틴 화면 패딩 영역 수정

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/recommendroutine/RecommendRoutineScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/recommendroutine/RecommendRoutineScreen.kt
@@ -173,10 +173,6 @@ private fun RecommendRoutineScreen(
                         onAddRoutineClick = { onRegisterRoutineClick(routine.id.toString()) },
                     )
                 }
-
-                item {
-                    Spacer(modifier = Modifier.height(110.dp))
-                }
             }
         }
     }


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
[추천 루틴 화면 패딩 영역관련 이슈](https://github.com/YAPP-Github/Bitnagil-Android/issues/76)를 해결했습니다.

## Related issue
- closed #76 

## Screenshot 📸

https://github.com/user-attachments/assets/df423051-949f-48bc-8ee5-ea8763dbd6a6


## Work Description
- homeNavHost innerPadding 적용
- 추천 루틴 화면 패딩 영역 수정

## To Reviewers 📢
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 홈 화면에서 내비게이션 호스트의 패딩 처리가 명확하게 조정되어, 스캐폴드의 인셋이 0으로 설정되었습니다.

* **개선사항**
  * 추천 루틴 화면의 목록 하단에 110dp 높이의 여백이 추가되어, 스크롤 시 하단 공간이 넉넉해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->