### PR TITLE
[UI 배경 색상 설정 이후 statusBar 패딩이 적용되도록 수정

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionScreen.kt
@@ -86,8 +86,8 @@ private fun EmotionScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(color = BitnagilTheme.colors.white),
+            .background(color = BitnagilTheme.colors.white)
+            .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         BitnagilTopBar(

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/intro/IntroScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/intro/IntroScreen.kt
@@ -66,8 +66,8 @@ private fun IntroScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(BitnagilTheme.colors.white),
+            .background(BitnagilTheme.colors.white)
+            .statusBarsPadding(),
     ) {
         Spacer(modifier = Modifier.height(screenHeight * 0.105f))
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginScreen.kt
@@ -82,8 +82,8 @@ private fun LoginScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(BitnagilTheme.colors.white),
+            .background(BitnagilTheme.colors.white)
+            .statusBarsPadding(),
     ) {
         Spacer(modifier = Modifier.height(screenHeight * 0.105f))
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/onboarding/OnBoardingScreen.kt
@@ -67,8 +67,8 @@ private fun OnBoardingScreen(
 ) {
     Column(
         modifier = Modifier
-            .statusBarsPadding()
-            .background(BitnagilTheme.colors.coolGray99),
+            .background(BitnagilTheme.colors.coolGray99)
+            .statusBarsPadding(),
     ) {
         BitnagilProgressTopBar(
             onBackClick = onClickPreviousInSelectOnBoarding,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingScreen.kt
@@ -85,8 +85,8 @@ private fun SettingScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(color = BitnagilTheme.colors.white),
+            .background(color = BitnagilTheme.colors.white)
+            .statusBarsPadding(),
     ) {
         BitnagilTopBar(
             title = "설정",

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementScreen.kt
@@ -101,8 +101,8 @@ private fun TermsAgreementScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(BitnagilTheme.colors.white),
+            .background(BitnagilTheme.colors.white)
+            .statusBarsPadding(),
     ) {
         BitnagilTopBar(
             title = "약관 동의",

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/webview/BitnagilWebViewScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/webview/BitnagilWebViewScreen.kt
@@ -64,8 +64,8 @@ fun BitnagilWebViewScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .background(BitnagilTheme.colors.white),
+            .background(BitnagilTheme.colors.white)
+            .statusBarsPadding(),
     ) {
         BitnagilTopBar(
             title = title,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineScreen.kt
@@ -105,11 +105,11 @@ private fun WriteRoutineScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .background(color = BitnagilTheme.colors.white)
             .statusBarsPadding()
             .windowInsetsPadding(
                 WindowInsets.ime.exclude(WindowInsets.navigationBars),
-            )
-            .background(color = BitnagilTheme.colors.white),
+            ),
     ) {
         BitnagilTopBar(
             title = if (state.writeRoutineType == WriteRoutineType.ADD) "루틴 등록" else "루틴 수정",


### PR DESCRIPTION
# [ PR Content ]
일부 화면에서 statusBar 영역 색상과 화면 내 배경 색상이 일치하지 않은 문제를 수정합니다.

## Related issue
- closed #82

## Screenshot 📸
x

## Work Description
- statusBarsPadding이 background 전에 설정되던 부분을 background이후에 적용되도록 수정

## To Reviewers 📢
x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 여러 화면에서 배경색과 상태바 패딩의 적용 순서가 변경되어, 배경색이 먼저 적용된 후 상태바 패딩이 추가됩니다.  
  * UI 요소나 기능에는 변화가 없으며, 일부 레이아웃의 시각적 일관성이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->