### PR TITLE
[FIX/#86] 감정 구슬 기반 추천 루틴 추가 반영 문제 수정

### DIFF
--- a/data/src/main/java/com/threegap/bitnagil/data/onboarding/repositoryImpl/OnBoardingRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/onboarding/repositoryImpl/OnBoardingRepositoryImpl.kt
@@ -7,7 +7,11 @@ import com.threegap.bitnagil.data.onboarding.model.request.RegisterOnBoardingRec
 import com.threegap.bitnagil.domain.onboarding.model.OnBoarding
 import com.threegap.bitnagil.domain.onboarding.model.OnBoardingAbstract
 import com.threegap.bitnagil.domain.onboarding.model.OnBoardingRecommendRoutine
+import com.threegap.bitnagil.domain.onboarding.model.OnBoardingRecommendRoutineEvent
 import com.threegap.bitnagil.domain.onboarding.repository.OnBoardingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
 
 class OnBoardingRepositoryImpl @Inject constructor(
@@ -52,6 +56,13 @@ class OnBoardingRepositoryImpl @Inject constructor(
             recommendedRoutineIds = selectedRecommendRoutineIds.mapNotNull { it.toIntOrNull() },
         )
 
-        return onBoardingDataSource.registerRecommendRoutineList(selectedRecommendRoutineIds = request.recommendedRoutineIds)
+        return onBoardingDataSource.registerRecommendRoutineList(selectedRecommendRoutineIds = request.recommendedRoutineIds).also {
+            if (it.isSuccess) {
+                _onBoardingRecommendRoutineEventFlow.emit(OnBoardingRecommendRoutineEvent.AddRoutines(selectedRecommendRoutineIds))
+            }
+        }
     }
+
+    private val _onBoardingRecommendRoutineEventFlow = MutableSharedFlow<OnBoardingRecommendRoutineEvent>()
+    override suspend fun getOnBoardingRecommendRoutineEventFlow(): Flow<OnBoardingRecommendRoutineEvent> = _onBoardingRecommendRoutineEventFlow.asSharedFlow()
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/model/OnBoardingRecommendRoutineEvent.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/model/OnBoardingRecommendRoutineEvent.kt
@@ -1,0 +1,5 @@
+package com.threegap.bitnagil.domain.onboarding.model
+
+sealed interface OnBoardingRecommendRoutineEvent {
+    data class AddRoutines(val routineIds: List<String>) : OnBoardingRecommendRoutineEvent
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/repository/OnBoardingRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/repository/OnBoardingRepository.kt
@@ -3,10 +3,13 @@ package com.threegap.bitnagil.domain.onboarding.repository
 import com.threegap.bitnagil.domain.onboarding.model.OnBoarding
 import com.threegap.bitnagil.domain.onboarding.model.OnBoardingAbstract
 import com.threegap.bitnagil.domain.onboarding.model.OnBoardingRecommendRoutine
+import com.threegap.bitnagil.domain.onboarding.model.OnBoardingRecommendRoutineEvent
+import kotlinx.coroutines.flow.Flow
 
 interface OnBoardingRepository {
     suspend fun getOnBoardingList(): List<OnBoarding>
     suspend fun getOnBoardingAbstract(selectedItemIdsWithOnBoardingId: List<Pair<String, List<String>>>): OnBoardingAbstract
     suspend fun getRecommendOnBoardingRouteList(selectedItemIdsWithOnBoardingId: List<Pair<String, List<String>>>): Result<List<OnBoardingRecommendRoutine>>
     suspend fun registerRecommendRoutineList(selectedRecommendRoutineIds: List<String>): Result<Unit>
+    suspend fun getOnBoardingRecommendRoutineEventFlow(): Flow<OnBoardingRecommendRoutineEvent>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/usecase/GetOnBoardingRecommendRoutineEventFlowUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/onboarding/usecase/GetOnBoardingRecommendRoutineEventFlowUseCase.kt
@@ -1,0 +1,14 @@
+package com.threegap.bitnagil.domain.onboarding.usecase
+
+import com.threegap.bitnagil.domain.onboarding.model.OnBoardingRecommendRoutineEvent
+import com.threegap.bitnagil.domain.onboarding.repository.OnBoardingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetOnBoardingRecommendRoutineEventFlowUseCase @Inject constructor(
+    private val repository: OnBoardingRepository,
+) {
+    suspend operator fun invoke(): Flow<OnBoardingRecommendRoutineEvent> {
+        return repository.getOnBoardingRecommendRoutineEventFlow()
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.threegap.bitnagil.domain.emotion.usecase.GetEmotionChangeEventFlowUseCase
 import com.threegap.bitnagil.domain.emotion.usecase.GetEmotionUseCase
+import com.threegap.bitnagil.domain.onboarding.usecase.GetOnBoardingRecommendRoutineEventFlowUseCase
 import com.threegap.bitnagil.domain.routine.model.RoutineCompletion
 import com.threegap.bitnagil.domain.routine.model.RoutineCompletionInfo
 import com.threegap.bitnagil.domain.routine.usecase.DeleteRoutineByDayUseCase
@@ -47,6 +48,7 @@ class HomeViewModel @Inject constructor(
     private val deleteRoutineByDayUseCase: DeleteRoutineByDayUseCase,
     private val getWriteRoutineEventFlowUseCase: GetWriteRoutineEventFlowUseCase,
     private val getEmotionChangeEventFlowUseCase: GetEmotionChangeEventFlowUseCase,
+    private val getOnBoardingRecommendRoutineEventFlowUseCase: GetOnBoardingRecommendRoutineEventFlowUseCase,
 ) : MviViewModel<HomeState, HomeSideEffect, HomeIntent>(
     initState = HomeState(),
     savedStateHandle = savedStateHandle,
@@ -58,6 +60,7 @@ class HomeViewModel @Inject constructor(
     init {
         observeWriteRoutineEvent()
         observeEmotionChangeEvent()
+        observeRecommendRoutineEvent()
         observeWeekChanges()
         observeRoutineUpdates()
         fetchWeeklyRoutines(container.stateFlow.value.currentWeeks)
@@ -247,6 +250,14 @@ class HomeViewModel @Inject constructor(
             getEmotionChangeEventFlowUseCase().collect {
                 val currentDate = LocalDate.now()
                 getMyEmotion(currentDate)
+            }
+        }
+    }
+
+    private fun observeRecommendRoutineEvent() {
+        viewModelScope.launch {
+            getOnBoardingRecommendRoutineEventFlowUseCase().collect {
+                fetchWeeklyRoutines(stateFlow.value.currentWeeks)
             }
         }
     }


### PR DESCRIPTION
# [ PR Content ]
감정 구슬을 선택하면 나오는 추천 루틴을 등록하였을 때 해당 루틴이 홈 화면에 바로 반영되지 않는 문제를 수정합니다.

## Related issue
- closed #86

## Screenshot 📸

[Screen_recording_20250809_185924.webm](https://github.com/user-attachments/assets/830dbe9b-f070-4b1b-8a77-afeab07c5edd)


## Work Description
- 홈 화면에서 추천 루틴을 등록했는지 여부를 감지하여 추천 루틴 등록 이벤트가 감지되었을 경우 현재 표시되는 주의 루틴을 다시 로드하도록 구현

## To Reviewers 📢
- 관련 UseCase, Repository메서드 로직들이 onBoarding 도메인에 구현되어 있는데, 이는 현재 추천 루틴을 등록하는 api주소가 api/v1/onboardings/routines 이기 때문에 api호출부의 통일성을 유지하기 위함입니다!
- 추가적으로 궁금한 점 있으시면 코멘트 부탁드립니다!
