### PR TITLE
[Feature/#116] 앱 강제 업데이트 로직을 구현합니다.

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
@@ -14,6 +14,8 @@ import com.threegap.bitnagil.data.routine.datasource.RoutineRemoteDataSource
 import com.threegap.bitnagil.data.routine.datasourceImpl.RoutineRemoteDataSourceImpl
 import com.threegap.bitnagil.data.user.datasource.UserDataSource
 import com.threegap.bitnagil.data.user.datasourceImpl.UserDataSourceImpl
+import com.threegap.bitnagil.data.version.datasource.VersionDataSource
+import com.threegap.bitnagil.data.version.datasourceImpl.VersionDataSourceImpl
 import com.threegap.bitnagil.data.writeroutine.datasource.WriteRoutineDataSource
 import com.threegap.bitnagil.data.writeroutine.datasourceImpl.WriteRoutineDataSourceImpl
 import dagger.Binds
@@ -57,4 +59,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindRecommendRoutineDataSource(recommendRoutineDataSourceImpl: RecommendRoutineDataSourceImpl): RecommendRoutineDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindVersionDataSource(versionDataSourceImpl: VersionDataSourceImpl): VersionDataSource
 }

--- a/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
@@ -6,6 +6,7 @@ import com.threegap.bitnagil.data.onboarding.repositoryImpl.OnBoardingRepository
 import com.threegap.bitnagil.data.recommendroutine.repositoryImpl.RecommendRoutineRepositoryImpl
 import com.threegap.bitnagil.data.routine.repositoryImpl.RoutineRepositoryImpl
 import com.threegap.bitnagil.data.user.repositoryImpl.UserRepositoryImpl
+import com.threegap.bitnagil.data.version.repositoryImpl.VersionRepositoryImpl
 import com.threegap.bitnagil.data.writeroutine.repositoryImpl.WriteRoutineRepositoryImpl
 import com.threegap.bitnagil.domain.auth.repository.AuthRepository
 import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
@@ -13,6 +14,7 @@ import com.threegap.bitnagil.domain.onboarding.repository.OnBoardingRepository
 import com.threegap.bitnagil.domain.recommendroutine.repository.RecommendRoutineRepository
 import com.threegap.bitnagil.domain.routine.repository.RoutineRepository
 import com.threegap.bitnagil.domain.user.repository.UserRepository
+import com.threegap.bitnagil.domain.version.repository.VersionRepository
 import com.threegap.bitnagil.domain.writeroutine.repository.WriteRoutineRepository
 import dagger.Binds
 import dagger.Module
@@ -51,4 +53,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindRecommendRoutineRepository(recommendRoutineRepositoryImpl: RecommendRoutineRepositoryImpl): RecommendRoutineRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindVersionRepository(versionRepositoryImpl: VersionRepositoryImpl): VersionRepository
 }

--- a/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
@@ -6,6 +6,7 @@ import com.threegap.bitnagil.data.onboarding.service.OnBoardingService
 import com.threegap.bitnagil.data.recommendroutine.service.RecommendRoutineService
 import com.threegap.bitnagil.data.routine.service.RoutineService
 import com.threegap.bitnagil.data.user.service.UserService
+import com.threegap.bitnagil.data.version.service.VersionService
 import com.threegap.bitnagil.data.writeroutine.service.WriteRoutineService
 import com.threegap.bitnagil.di.core.Auth
 import com.threegap.bitnagil.di.core.NoneAuth
@@ -60,4 +61,9 @@ object ServiceModule {
     @Singleton
     fun provideRecommendRoutineService(@Auth retrofit: Retrofit): RecommendRoutineService =
         retrofit.create(RecommendRoutineService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideVersionService(@NoneAuth retrofit: Retrofit): VersionService =
+        retrofit.create(VersionService::class.java)
 }

--- a/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/AndroidApplicationPlugin.kt
@@ -1,6 +1,7 @@
 package com.threegap.bitnagil.convention
 
 import com.android.build.api.dsl.ApplicationExtension
+import com.threegap.bitnagil.convention.extension.configureAppVersion
 import com.threegap.bitnagil.convention.extension.configureComposeAndroid
 import com.threegap.bitnagil.convention.extension.configureKotlinAndroid
 import org.gradle.api.Plugin
@@ -21,10 +22,10 @@ class AndroidApplicationPlugin : Plugin<Project> {
         extensions.configure<ApplicationExtension> {
             configureKotlinAndroid(this)
             configureComposeAndroid(this)
+            configureAppVersion()
             with(defaultConfig) {
                 targetSdk = libs.findVersion("targetSdk").get().requiredVersion.toInt()
                 versionCode = libs.findVersion("versionCode").get().requiredVersion.toInt()
-                versionName = libs.findVersion("versionName").get().requiredVersion
             }
         }
     }

--- a/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/AndroidLibraryPlugin.kt
+++ b/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/AndroidLibraryPlugin.kt
@@ -1,6 +1,7 @@
 package com.threegap.bitnagil.convention
 
 import com.android.build.gradle.LibraryExtension
+import com.threegap.bitnagil.convention.extension.configureAppVersion
 import com.threegap.bitnagil.convention.extension.configureKotlinAndroid
 import com.threegap.bitnagil.convention.extension.configureKotlinCoroutine
 import org.gradle.api.Plugin
@@ -17,6 +18,7 @@ class AndroidLibraryPlugin : Plugin<Project> {
         extensions.configure<LibraryExtension> {
             configureKotlinAndroid(this)
             configureKotlinCoroutine(this)
+            configureAppVersion()
         }
     }
 }

--- a/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/extension/AppVersion.kt
+++ b/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/extension/AppVersion.kt
@@ -1,0 +1,37 @@
+package com.threegap.bitnagil.convention.extension
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByType
+
+internal fun Project.configureAppVersion() {
+    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+    val major = libs.findVersion("versionMajor").get().requiredVersion
+    val minor = libs.findVersion("versionMinor").get().requiredVersion
+    val patch = libs.findVersion("versionPatch").get().requiredVersion
+
+    extensions.findByType<ApplicationExtension>()?.let { appExtension ->
+        appExtension.defaultConfig {
+            versionName = "$major.$minor.$patch"
+            buildConfigField("int", "VERSION_MAJOR", major)
+            buildConfigField("int", "VERSION_MINOR", minor)
+            buildConfigField("int", "VERSION_PATCH", patch)
+        }
+    }
+
+    extensions.findByType<LibraryExtension>()?.let { libExtension ->
+        libExtension.apply {
+            defaultConfig {
+                buildConfigField("int", "VERSION_MAJOR", major)
+                buildConfigField("int", "VERSION_MINOR", minor)
+                buildConfigField("int", "VERSION_PATCH", patch)
+            }
+            buildFeatures {
+                buildConfig = true
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/version/datasource/VersionDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/version/datasource/VersionDataSource.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.data.version.datasource
+
+import com.threegap.bitnagil.data.version.model.response.VersionCheckResponseDto
+
+interface VersionDataSource {
+    suspend fun checkVersion(): Result<VersionCheckResponseDto>
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/version/datasourceImpl/VersionDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/version/datasourceImpl/VersionDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.threegap.bitnagil.data.version.datasourceImpl
+
+import com.threegap.bitnagil.data.BuildConfig
+import com.threegap.bitnagil.data.common.safeApiCall
+import com.threegap.bitnagil.data.version.datasource.VersionDataSource
+import com.threegap.bitnagil.data.version.model.response.VersionCheckResponseDto
+import com.threegap.bitnagil.data.version.service.VersionService
+import javax.inject.Inject
+
+class VersionDataSourceImpl @Inject constructor(
+    private val versionService: VersionService,
+) : VersionDataSource {
+
+    override suspend fun checkVersion(): Result<VersionCheckResponseDto> =
+        safeApiCall {
+            versionService.checkVersion(
+                majorVersion = BuildConfig.VERSION_MAJOR,
+                minorVersion = BuildConfig.VERSION_MINOR,
+                patchVersion = BuildConfig.VERSION_PATCH,
+            )
+        }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/version/model/response/VersionCheckResponseDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/version/model/response/VersionCheckResponseDto.kt
@@ -1,0 +1,16 @@
+package com.threegap.bitnagil.data.version.model.response
+
+import com.threegap.bitnagil.domain.version.model.UpdateRequirement
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VersionCheckResponseDto(
+    @SerialName("forceUpdateYn")
+    val forceUpdateYn: Boolean,
+)
+
+fun VersionCheckResponseDto.toDomain() =
+    UpdateRequirement(
+        isForced = this.forceUpdateYn,
+    )

--- a/data/src/main/java/com/threegap/bitnagil/data/version/repositoryImpl/VersionRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/version/repositoryImpl/VersionRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.threegap.bitnagil.data.version.repositoryImpl
+
+import com.threegap.bitnagil.data.version.datasource.VersionDataSource
+import com.threegap.bitnagil.data.version.model.response.toDomain
+import com.threegap.bitnagil.domain.version.model.UpdateRequirement
+import com.threegap.bitnagil.domain.version.repository.VersionRepository
+import javax.inject.Inject
+
+class VersionRepositoryImpl @Inject constructor(
+    private val versionDataSource: VersionDataSource,
+) : VersionRepository {
+
+    override suspend fun checkVersion(): Result<UpdateRequirement> =
+        versionDataSource.checkVersion().map { it.toDomain() }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/version/service/VersionService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/version/service/VersionService.kt
@@ -1,0 +1,15 @@
+package com.threegap.bitnagil.data.version.service
+
+import com.threegap.bitnagil.data.version.model.response.VersionCheckResponseDto
+import com.threegap.bitnagil.network.model.BaseResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface VersionService {
+    @GET("/api/v1/version/android/check")
+    suspend fun checkVersion(
+        @Query("major") majorVersion: Int,
+        @Query("minor") minorVersion: Int,
+        @Query("patch") patchVersion: Int,
+    ): BaseResponse<VersionCheckResponseDto>
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/version/model/UpdateRequirement.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/version/model/UpdateRequirement.kt
@@ -1,0 +1,5 @@
+package com.threegap.bitnagil.domain.version.model
+
+data class UpdateRequirement(
+    val isForced: Boolean,
+)

--- a/domain/src/main/java/com/threegap/bitnagil/domain/version/repository/VersionRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/version/repository/VersionRepository.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.domain.version.repository
+
+import com.threegap.bitnagil.domain.version.model.UpdateRequirement
+
+interface VersionRepository {
+    suspend fun checkVersion(): Result<UpdateRequirement>
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/version/usecase/CheckUpdateRequirementUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/version/usecase/CheckUpdateRequirementUseCase.kt
@@ -1,0 +1,11 @@
+package com.threegap.bitnagil.domain.version.usecase
+
+import com.threegap.bitnagil.domain.version.repository.VersionRepository
+import javax.inject.Inject
+
+class CheckUpdateRequirementUseCase @Inject constructor(
+    private val versionRepository: VersionRepository,
+) {
+    suspend operator fun invoke(): Result<Boolean> =
+        versionRepository.checkVersion().map { it.isForced }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,9 @@ targetSdk = "35"
 
 ## App Versioning
 versionCode = "4"
-versionName = "1.0.2"
+versionMajor = "1"
+versionMinor = "0"
+versionPatch = "2"
 
 # Android Gradle Plugin
 androidGradlePlugin = "8.10.1"

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashScreen.kt
@@ -1,5 +1,6 @@
 package com.threegap.bitnagil.presentation.splash
 
+import androidx.activity.ComponentActivity
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.background
@@ -16,15 +17,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.threegap.bitnagil.designsystem.BitnagilTheme
 import com.threegap.bitnagil.designsystem.R
 import com.threegap.bitnagil.designsystem.component.atom.BitnagilIcon
 import com.threegap.bitnagil.presentation.splash.component.template.BitnagilLottieAnimation
+import com.threegap.bitnagil.presentation.splash.component.template.ForceUpdateDialog
 import com.threegap.bitnagil.presentation.splash.model.SplashSideEffect
+import com.threegap.bitnagil.presentation.splash.util.openAppInPlayStore
 import org.orbitmvi.orbit.compose.collectSideEffect
+import kotlin.system.exitProcess
 
 @Composable
 fun SplashScreenContainer(
@@ -34,6 +40,10 @@ fun SplashScreenContainer(
     navigateToHome: () -> Unit,
     viewModel: SplashViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
+    val activity = context as? ComponentActivity
+    val uiState by viewModel.stateFlow.collectAsStateWithLifecycle()
+
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is SplashSideEffect.NavigateToLogin -> navigateToLogin()
@@ -46,6 +56,16 @@ fun SplashScreenContainer(
     SplashScreen(
         onCompleted = viewModel::onAnimationCompleted,
     )
+
+    if (uiState.forceUpdateRequired) {
+        ForceUpdateDialog(
+            onUpdateClick = { openAppInPlayStore(activity) },
+            onDismissRequest = {
+                activity?.finishAffinity()
+                exitProcess(0)
+            },
+        )
+    }
 }
 
 @Composable

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.threegap.bitnagil.domain.auth.model.UserRole
 import com.threegap.bitnagil.domain.auth.usecase.AutoLoginUseCase
+import com.threegap.bitnagil.domain.version.usecase.CheckUpdateRequirementUseCase
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
 import com.threegap.bitnagil.presentation.splash.model.SplashIntent
 import com.threegap.bitnagil.presentation.splash.model.SplashSideEffect
@@ -18,6 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val checkUpdateRequirementUseCase: CheckUpdateRequirementUseCase,
     private val autoLoginUseCase: AutoLoginUseCase,
 ) : MviViewModel<SplashState, SplashSideEffect, SplashIntent>(
     initState = SplashState(),
@@ -25,7 +27,7 @@ class SplashViewModel @Inject constructor(
 ) {
 
     init {
-        performAutoLogin()
+        performForceUpdateCheck()
     }
 
     override suspend fun SimpleSyntax<SplashState, SplashSideEffect>.reduceState(
@@ -37,6 +39,13 @@ class SplashViewModel @Inject constructor(
                 state.copy(
                     userRole = intent.userRole,
                     isAutoLoginCompleted = true,
+                )
+            }
+
+            is SplashIntent.SetForceUpdateResult -> {
+                state.copy(
+                    forceUpdateRequired = intent.isRequired,
+                    isForceUpdateCheckCompleted = true,
                 )
             }
 
@@ -61,6 +70,20 @@ class SplashViewModel @Inject constructor(
             }
         }
 
+    private fun performForceUpdateCheck() {
+        viewModelScope.launch {
+            val isUpdateRequired = withTimeoutOrNull(5000) {
+                checkUpdateRequirementUseCase().getOrElse { false }
+            } ?: false
+
+            sendIntent(SplashIntent.SetForceUpdateResult(isUpdateRequired))
+
+            if (!isUpdateRequired) {
+                performAutoLogin()
+            }
+        }
+    }
+
     private fun performAutoLogin() {
         viewModelScope.launch {
             try {
@@ -76,6 +99,9 @@ class SplashViewModel @Inject constructor(
 
     fun onAnimationCompleted() {
         val splashState = container.stateFlow.value
+
+        if (splashState.forceUpdateRequired) return
+
         if (!splashState.isAutoLoginCompleted) {
             viewModelScope.launch {
                 delay(100)

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/component/template/ForceUpdateDialog.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/component/template/ForceUpdateDialog.kt
@@ -1,0 +1,102 @@
+package com.threegap.bitnagil.presentation.splash.component.template
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.designsystem.component.atom.BitnagilTextButton
+import com.threegap.bitnagil.designsystem.component.atom.BitnagilTextButtonColor
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ForceUpdateDialog(
+    onUpdateClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicAlertDialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+        ),
+        modifier = modifier
+            .background(
+                color = BitnagilTheme.colors.white,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .padding(vertical = 20.dp, horizontal = 24.dp),
+    ) {
+        Column(
+            modifier = Modifier,
+        ) {
+            Text(
+                text = "최신 버전으로 업데이트가 필요해요",
+                color = BitnagilTheme.colors.coolGray10,
+                style = BitnagilTheme.typography.subtitle1SemiBold.copy(
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.None,
+                    ),
+                ),
+            )
+
+            Text(
+                text = "더 안정적이고 안전한 서비스를 위해\n최신 버전으로 업데이트해 주세요.",
+                color = BitnagilTheme.colors.coolGray40,
+                style = BitnagilTheme.typography.body2Medium.copy(
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.None,
+                    ),
+                ),
+            )
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                BitnagilTextButton(
+                    text = "나가기",
+                    onClick = onDismissRequest,
+                    colors = BitnagilTextButtonColor.cancel(),
+                    textStyle = BitnagilTheme.typography.body2Medium,
+                    modifier = Modifier.weight(1f),
+                )
+
+                BitnagilTextButton(
+                    text = "업데이트",
+                    onClick = onUpdateClick,
+                    textStyle = BitnagilTheme.typography.body2Medium,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ForceUpdateDialogPreview() {
+    ForceUpdateDialog(
+        onUpdateClick = {},
+        onDismissRequest = {},
+    )
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashIntent.kt
@@ -9,4 +9,5 @@ sealed class SplashIntent : MviIntent {
     data object NavigateToHome : SplashIntent()
     data object NavigateToTermsAgreement : SplashIntent()
     data object NavigateToOnboarding : SplashIntent()
+    data class SetForceUpdateResult(val isRequired: Boolean) : SplashIntent()
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/model/SplashState.kt
@@ -8,4 +8,6 @@ import kotlinx.parcelize.Parcelize
 data class SplashState(
     val userRole: UserRole? = null,
     val isAutoLoginCompleted: Boolean = false,
+    val isForceUpdateCheckCompleted: Boolean = false,
+    val forceUpdateRequired: Boolean = false,
 ) : MviState

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/util/PlayStoreUtils.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/util/PlayStoreUtils.kt
@@ -1,0 +1,70 @@
+package com.threegap.bitnagil.presentation.splash.util
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.system.exitProcess
+
+private const val PACKAGE_NAME = "com.threegap.bitnagil"
+private const val GOOGLE_PLAY_PACKAGE = "com.android.vending"
+private const val APP_EXIT_DELAY = 500L
+
+fun openAppInPlayStore(
+    activity: ComponentActivity?,
+    shouldFinishApp: Boolean = true,
+) {
+    activity?.let {
+        val isSuccess = tryOpenPlayStore(it) || tryOpenWebBrowser(it)
+
+        if (isSuccess && shouldFinishApp) {
+            finishAppWithDelay(it)
+        }
+    }
+}
+
+private fun tryOpenPlayStore(activity: ComponentActivity): Boolean =
+    try {
+        val intent = createPlayStoreIntent()
+        activity.startActivity(intent)
+        true
+    } catch (e: ActivityNotFoundException) {
+        false
+    }
+
+private fun tryOpenWebBrowser(activity: ComponentActivity): Boolean =
+    try {
+        val intent = createWebIntent()
+        activity.startActivity(intent)
+        true
+    } catch (e: Exception) {
+        false
+    }
+
+private fun createPlayStoreIntent(): Intent =
+    Intent(
+        Intent.ACTION_VIEW,
+        "market://details?id=$PACKAGE_NAME".toUri(),
+    ).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        setPackage(GOOGLE_PLAY_PACKAGE)
+    }
+
+private fun createWebIntent(): Intent =
+    Intent(
+        Intent.ACTION_VIEW,
+        "https://play.google.com/store/apps/details?id=$PACKAGE_NAME".toUri(),
+    ).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+
+private fun finishAppWithDelay(activity: ComponentActivity) {
+    activity.lifecycleScope.launch {
+        delay(APP_EXIT_DELAY)
+        activity.finishAffinity()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
앱 강제 업데이트 로직을 구현했습니다.

## Related issue
- closed #116  

## Screenshot 📸

https://github.com/user-attachments/assets/8bafbe93-a25a-4c83-b0ea-f654908cd8b9

## Work Description
- 강제 업데이트 로직 구현
- 앱 버전 api 연동
- 버전 컨벤션 플러그인 설정

## To Reviewers 📢
- 스플래시 화면 진입 시 버전 확인 api의 응답(Boolean)여부를 통해 강제 업데이트를 유도하도록 구현했습니다.
- 응답이 false 인 경우 자동 로그인 api를 호출하도록 구현했습니다! (강제 업데이트가 true응답이 올 경우 불필요한 자동로그인 api를 호출한다 판단하여 병렬처리는 하지 않았습니다.)
- 추가로 생각해볼점:
해당 api의 응답이 true로 오는 경우가 흔하게 발생하는 상황이 아니라 생각이 되어 추후 캐싱등을 활용해서 해당 api 호출을 줄이는 방법으로 리펙하는것도 괜찮을거 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 스플래시에서 앱 강제 업데이트 필요 여부를 확인합니다.
  - 강제 업데이트 필요 시 해제 불가 안내 다이얼로그를 표시하고, ‘업데이트’로 플레이 스토어를 열거나 ‘나가기’로 앱을 종료할 수 있습니다.
  - 네트워크 오류/시간초과(5초) 시 업데이트가 필요 없는 것으로 간주하고 기존 흐름을 계속합니다.
- 작업
  - 버전 관리 방식을 major/minor/patch로 구조화하고 빌드에 버전 상수를 제공합니다. 사용자에게 보이는 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->