### PR TITLE
[FIX/#120] 루틴 작성시 추천 루틴 타입 누락 추가

### DIFF
--- a/data/src/main/java/com/threegap/bitnagil/data/writeroutine/model/request/RegisterRoutineRequest.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/writeroutine/model/request/RegisterRoutineRequest.kt
@@ -17,4 +17,6 @@ data class RegisterRoutineRequest(
     val executionTime: String,
     @SerialName("subRoutineName")
     val subRoutineName: List<String>,
+    @SerialName("recommendedRoutineType")
+    val recommendedRoutineType: String?,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/writeroutine/repositoryImpl/WriteRoutineRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/writeroutine/repositoryImpl/WriteRoutineRepositoryImpl.kt
@@ -24,6 +24,7 @@ class WriteRoutineRepositoryImpl @Inject constructor(
         startDate: Date,
         endDate: Date,
         subRoutines: List<String>,
+        recommendedRoutineType: String?,
     ): Result<Unit> {
         val request = RegisterRoutineRequest(
             routineName = name,
@@ -32,6 +33,7 @@ class WriteRoutineRepositoryImpl @Inject constructor(
             routineStartDate = startDate.toFormattedString(),
             routineEndDate = endDate.toFormattedString(),
             subRoutineName = subRoutines,
+            recommendedRoutineType = recommendedRoutineType,
         )
         return writeRoutineDataSource.registerRoutine(request).also {
             if (it.isSuccess) {

--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/repository/WriteRoutineRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/repository/WriteRoutineRepository.kt
@@ -15,6 +15,7 @@ interface WriteRoutineRepository {
         startDate: Date,
         endDate: Date,
         subRoutines: List<String>,
+        recommendedRoutineType: String?,
     ): Result<Unit>
 
     suspend fun editRoutine(

--- a/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/RegisterRoutineUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/writeroutine/usecase/RegisterRoutineUseCase.kt
@@ -16,6 +16,7 @@ class RegisterRoutineUseCase @Inject constructor(
         startDate: Date,
         endDate: Date,
         subRoutines: List<String>,
+        recommendedRoutineType: String?,
     ): Result<Unit> {
         return writeRoutineRepository.registerRoutine(
             name = name,
@@ -24,6 +25,7 @@ class RegisterRoutineUseCase @Inject constructor(
             startDate = startDate,
             endDate = endDate,
             subRoutines = subRoutines,
+            recommendedRoutineType = recommendedRoutineType,
         )
     }
 }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
@@ -93,6 +93,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
                             ),
                             startDate = Date.fromString(routine.startDate),
                             endDate = Date.fromString(routine.endDate),
+                            recommendedRoutineType = null,
                         ),
                     )
                 },
@@ -121,6 +122,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
                             ),
                             startDate = Date.now(),
                             endDate = Date.now(),
+                            recommendedRoutineType = routine.recommendedRoutineType.categoryName,
                         ),
                     )
                 },
@@ -134,7 +136,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
     override suspend fun SimpleSyntax<WriteRoutineState, WriteRoutineSideEffect>.reduceState(
         intent: WriteRoutineIntent,
         state: WriteRoutineState,
-    ): WriteRoutineState {
+    ): WriteRoutineState? {
         when (intent) {
             WriteRoutineIntent.SelectAllTime -> {
                 return state.copy(
@@ -221,9 +223,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
             WriteRoutineIntent.RegisterRoutineSuccess -> {
                 sendSideEffect(WriteRoutineSideEffect.MoveToPreviousScreen)
 
-                return state.copy(
-                    loading = false,
-                )
+                return null
             }
             WriteRoutineIntent.RegisterRoutineLoading -> {
                 return state.copy(
@@ -254,6 +254,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
                     endDate = intent.endDate,
                     subRoutineNames = intent.subRoutines,
                     loading = false,
+                    recommendedRoutineType = intent.recommendedRoutineType,
                 )
             }
 
@@ -449,6 +450,8 @@ class WriteRoutineViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val currentState = stateFlow.value
 
+            if (currentState.loading) return@launch
+
             val startTime = currentState.startTime ?: return@launch
 
             val repeatDay = when (currentState.repeatType) {
@@ -483,6 +486,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
                         startDate = if (noRepeatRoutine) Date.now().toDomainDate() else currentState.startDate.toDomainDate(),
                         endDate = if (noRepeatRoutine) Date.now().toDomainDate() else currentState.endDate.toDomainDate(),
                         subRoutines = subRoutines,
+                        recommendedRoutineType = currentState.recommendedRoutineType,
                     )
 
                     if (registerRoutineResult.isSuccess) {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/model/mvi/WriteRoutineIntent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/model/mvi/WriteRoutineIntent.kt
@@ -22,6 +22,7 @@ sealed class WriteRoutineIntent : MviIntent {
         val subRoutines: List<String>,
         val startDate: Date,
         val endDate: Date,
+        val recommendedRoutineType: String?,
     ) : WriteRoutineIntent()
     data object SelectAllTime : WriteRoutineIntent()
     data object ShowTimePickerBottomSheet : WriteRoutineIntent()

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/model/mvi/WriteRoutineState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/model/mvi/WriteRoutineState.kt
@@ -29,6 +29,7 @@ data class WriteRoutineState(
     val repeatDaysUiExpanded: Boolean,
     val periodUiExpanded: Boolean,
     val startTimeUiExpanded: Boolean,
+    val recommendedRoutineType: String?,
 ) : MviState {
     companion object {
         val Init = WriteRoutineState(
@@ -79,6 +80,7 @@ data class WriteRoutineState(
             startTimeUiExpanded = false,
             startDate = Date.now(),
             endDate = Date.now(),
+            recommendedRoutineType = null,
         )
     }
 


### PR DESCRIPTION
# [ PR Content ]
루틴 작성시 누락된 추천 루틴 타입을 추가합니다.

## Related issue
- closed #120

## Screenshot 📸
https://github.com/user-attachments/assets/8bade282-33d6-4d9b-8428-d433400a87ac

## Work Description
- 루틴 작성 API 호출시 추천 루틴 타입을 같이 전송하도록 수정
- "등록하기"버튼을 빠르게 2번 클릭시 동일한 내용의 루틴이 2번 이상 등록될 수 있었던 문제 수정

## To Reviewers 📢
- 궁금한 점 있으면 코멘트 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 루틴 등록 시 추천 루틴 유형을 선택/전달할 수 있도록 지원합니다. 추천 루틴을 불러오면 해당 유형이 자동 반영됩니다.
- 버그 수정
  - 루틴 등록 중 중복 제출을 방지하여 동일 루틴이 여러 번 생성되는 문제를 예방했습니다.
- 개선
  - 루틴 작성 흐름에서 불필요한 상태 업데이트를 줄여 전환 및 내비게이션 응답성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->