### PR TITLE
[Fix/#127] 네비게이션 스택이 중복으로 생성되는 문제를 해결합니다.

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
@@ -30,6 +30,7 @@ fun HomeBottomNavigationBar(
     navController: NavController,
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
 
     Column {
         HorizontalDivider(
@@ -52,11 +53,15 @@ fun HomeBottomNavigationBar(
                     icon = homeRoute.icon,
                     title = homeRoute.title,
                     onClick = {
-                        navController.navigate(homeRoute.route) {
-                            popUpTo(0) { inclusive = true }
+                        if (currentRoute != homeRoute.route) {
+                            navController.navigate(homeRoute.route) {
+                                popUpTo(0) { inclusive = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
                         }
                     },
-                    selected = navBackStackEntry?.destination?.route == homeRoute.route,
+                    selected = currentRoute == homeRoute.route,
                 )
             }
         }

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
@@ -56,8 +56,6 @@ fun HomeBottomNavigationBar(
                         if (currentRoute != homeRoute.route) {
                             navController.navigate(homeRoute.route) {
                                 popUpTo(0) { inclusive = true }
-                                launchSingleTop = true
-                                restoreState = true
                             }
                         }
                     },


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## Related issue
- closed #127 

## Screenshot 📸
- N/A

## Work Description
- HomRoute간 중복 네비게이션 방지를 위한 로직 추가

## To Reviewers 📢
- 간단한 작업이지만 작업간 "두번 클릭 자체를 막기" vs "중복 생성을 막기" 에 대한 고민이 있었는데, 문제의 원인이 스택이 중복으로 생기는것이기 때문에 후자가 더 적합하다고 판단하여 "중복 생성" 자체를 방지하는 방향으로 구현해봤습니다~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 하단 탭의 선택 상태가 네비게이션 상태와 안정적으로 동기화되도록 개선
  - 이미 선택된 탭을 눌러도 중복 탐색이 발생하지 않도록 방지
  - 탭 전환 시 이전 화면 상태를 복원해 끊김 없는 탐색 경험 제공
  - 중복 스택 생성을 억제해 뒤로 가기 동작을 일관되게 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->