### PR TITLE
[Fix/#130] 루틴 수정 시 수정된 루틴 데이터를 fetch 하도록 수정합니다.

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/routinelist/RoutineListViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/routinelist/RoutineListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.threegap.bitnagil.domain.routine.usecase.DeleteRoutineForDayUseCase
 import com.threegap.bitnagil.domain.routine.usecase.DeleteRoutineUseCase
 import com.threegap.bitnagil.domain.routine.usecase.FetchWeeklyRoutinesUseCase
+import com.threegap.bitnagil.domain.writeroutine.usecase.GetWriteRoutineEventFlowUseCase
 import com.threegap.bitnagil.presentation.common.mviviewmodel.MviViewModel
 import com.threegap.bitnagil.presentation.home.util.getCurrentWeekDays
 import com.threegap.bitnagil.presentation.routinelist.model.RoutineListIntent
@@ -24,6 +25,7 @@ class RoutineListViewModel @Inject constructor(
     private val fetchWeeklyRoutinesUseCase: FetchWeeklyRoutinesUseCase,
     private val deleteRoutineUseCase: DeleteRoutineUseCase,
     private val deleteRoutineForDayUseCase: DeleteRoutineForDayUseCase,
+    private val getWriteRoutineEventFlowUseCase: GetWriteRoutineEventFlowUseCase,
 ) : MviViewModel<RoutineListState, RoutineListSideEffect, RoutineListIntent>(
     savedStateHandle = savedStateHandle,
     initState = RoutineListState(
@@ -38,6 +40,7 @@ class RoutineListViewModel @Inject constructor(
 
     init {
         fetchRoutines()
+        observeRoutineChanges()
     }
 
     override suspend fun SimpleSyntax<RoutineListState, RoutineListSideEffect>.reduceState(
@@ -112,6 +115,14 @@ class RoutineListViewModel @Inject constructor(
         }
 
         return newState
+    }
+
+    private fun observeRoutineChanges() {
+        viewModelScope.launch {
+            getWriteRoutineEventFlowUseCase().collect {
+                fetchRoutines()
+            }
+        }
     }
 
     private fun fetchRoutines() {


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## Related issue
- closed #130 

## Screenshot 📸
- N/A

## Work Description
- 기존에 구현되있는 로직을 활용했습니다.
  - 루틴 수정 시 발생하는 이벤트를 수집하여 루틴 데이터를 다시 fetch 할 수 있도록 구현했습니다.

## To Reviewers 📢
- 궁금하거나, 질문이 있다면 남겨주세요~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 루틴 작성/편집/삭제 등의 변경이 발생하면 루틴 목록이 자동으로 갱신됩니다. 수동 새로고침 없이 즉시 최신 상태를 확인할 수 있습니다.
  - 앱 실행 시 초기 로딩 후에도 변경 이벤트를 지속 감지해 리스트를 항상 최신으로 유지합니다. 연속 작업 시 반영 지연이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->