### PR TITLE
[Chore/#134] Orbit-MVI 라이브러리 버전을 업데이트 합니다. (v6.1.0 -> v10.0.0)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ espressoCore = "3.6.1"
 
 ## Other
 material = "1.12.0"
-orbit = "6.1.0"
+orbit = "10.0.0"
 javax = "1"
 kakaoLogin = "2.21.4"
 lottie-compose = "6.6.0"

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModel.kt
@@ -5,10 +5,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
-import org.orbitmvi.orbit.syntax.simple.intent
-import org.orbitmvi.orbit.syntax.simple.postSideEffect
-import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.viewmodel.container
 
 abstract class MviViewModel<STATE : MviState, SIDE_EFFECT : MviSideEffect, INTENT : MviIntent>(
@@ -20,12 +17,8 @@ abstract class MviViewModel<STATE : MviState, SIDE_EFFECT : MviSideEffect, INTEN
     val stateFlow: StateFlow<STATE> get() = container.stateFlow
     val sideEffectFlow: Flow<SIDE_EFFECT> get() = container.sideEffectFlow
 
-    protected suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.sendSideEffect(sideEffect: SIDE_EFFECT) = postSideEffect(sideEffect)
-
-    protected abstract suspend fun SimpleSyntax<STATE, SIDE_EFFECT>.reduceState(
-        intent: INTENT,
-        state: STATE,
-    ): STATE?
+    protected suspend fun Syntax<STATE, SIDE_EFFECT>.sendSideEffect(sideEffect: SIDE_EFFECT) = postSideEffect(sideEffect)
+    protected abstract suspend fun Syntax<STATE, SIDE_EFFECT>.reduceState(intent: INTENT, state: STATE): STATE?
 
     fun sendIntent(intent: INTENT) =
         intent {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/emotion/EmotionViewModel.kt
@@ -15,7 +15,7 @@ import com.threegap.bitnagil.presentation.emotion.model.mvi.EmotionState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -47,7 +47,7 @@ class EmotionViewModel @Inject constructor(
         }
     }
 
-    override suspend fun SimpleSyntax<EmotionState, EmotionSideEffect>.reduceState(intent: EmotionIntent, state: EmotionState): EmotionState? {
+    override suspend fun Syntax<EmotionState, EmotionSideEffect>.reduceState(intent: EmotionIntent, state: EmotionState): EmotionState? {
         when (intent) {
             is EmotionIntent.EmotionListLoadSuccess -> {
                 return state.copy(

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/guide/GuideViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/guide/GuideViewModel.kt
@@ -6,7 +6,7 @@ import com.threegap.bitnagil.presentation.guide.model.GuideIntent
 import com.threegap.bitnagil.presentation.guide.model.GuideSideEffect
 import com.threegap.bitnagil.presentation.guide.model.GuideState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,7 +16,7 @@ class GuideViewModel @Inject constructor(
     initState = GuideState(),
     savedStateHandle = savedStateHandle,
 ) {
-    override suspend fun SimpleSyntax<GuideState, GuideSideEffect>.reduceState(
+    override suspend fun Syntax<GuideState, GuideSideEffect>.reduceState(
         intent: GuideIntent,
         state: GuideState,
     ): GuideState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
@@ -22,13 +22,14 @@ import com.threegap.bitnagil.presentation.home.model.toUiModel
 import com.threegap.bitnagil.presentation.home.util.getCurrentWeekDays
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -61,7 +62,7 @@ class HomeViewModel @Inject constructor(
         fetchTodayEmotion(LocalDate.now())
     }
 
-    override suspend fun SimpleSyntax<HomeState, HomeSideEffect>.reduceState(
+    override suspend fun Syntax<HomeState, HomeSideEffect>.reduceState(
         intent: HomeIntent,
         state: HomeState,
     ): HomeState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/home/HomeViewModel.kt
@@ -22,7 +22,6 @@ import com.threegap.bitnagil.presentation.home.model.toUiModel
 import com.threegap.bitnagil.presentation.home.util.getCurrentWeekDays
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/login/LoginViewModel.kt
@@ -11,7 +11,7 @@ import com.threegap.bitnagil.presentation.login.model.LoginSideEffect
 import com.threegap.bitnagil.presentation.login.model.LoginState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,7 +22,7 @@ class LoginViewModel @Inject constructor(
     initState = LoginState(),
     savedStateHandle = savedStateHandle,
 ) {
-    override suspend fun SimpleSyntax<LoginState, LoginSideEffect>.reduceState(
+    override suspend fun Syntax<LoginState, LoginSideEffect>.reduceState(
         intent: LoginIntent,
         state: LoginState,
     ): LoginState? =

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/mypage/MyPageViewModel.kt
@@ -9,7 +9,7 @@ import com.threegap.bitnagil.presentation.mypage.model.MyPageSideEffect
 import com.threegap.bitnagil.presentation.mypage.model.MyPageState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,7 +41,7 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    override suspend fun SimpleSyntax<MyPageState, MyPageSideEffect>.reduceState(
+    override suspend fun Syntax<MyPageState, MyPageSideEffect>.reduceState(
         intent: MyPageIntent,
         state: MyPageState,
     ): MyPageState {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/onboarding/OnBoardingViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/onboarding/OnBoardingViewModel.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 
 @HiltViewModel(assistedFactory = OnBoardingViewModel.Factory::class)
 class OnBoardingViewModel @AssistedInject constructor(
@@ -119,7 +119,7 @@ class OnBoardingViewModel @AssistedInject constructor(
         }
     }
 
-    override suspend fun SimpleSyntax<OnBoardingState, OnBoardingSideEffect>.reduceState(
+    override suspend fun Syntax<OnBoardingState, OnBoardingSideEffect>.reduceState(
         intent: OnBoardingIntent,
         state: OnBoardingState,
     ): OnBoardingState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/recommendroutine/RecommendRoutineViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/recommendroutine/RecommendRoutineViewModel.kt
@@ -15,7 +15,7 @@ import com.threegap.bitnagil.presentation.recommendroutine.model.RecommendRoutin
 import com.threegap.bitnagil.presentation.recommendroutine.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,7 +35,7 @@ class RecommendRoutineViewModel @Inject constructor(
 
     private var recommendRoutines: RecommendRoutinesUiModel = RecommendRoutinesUiModel()
 
-    override suspend fun SimpleSyntax<RecommendRoutineState, RecommendRoutineSideEffect>.reduceState(
+    override suspend fun Syntax<RecommendRoutineState, RecommendRoutineSideEffect>.reduceState(
         intent: RecommendRoutineIntent,
         state: RecommendRoutineState,
     ): RecommendRoutineState? = when (intent) {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/routinelist/RoutineListViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/routinelist/RoutineListViewModel.kt
@@ -15,7 +15,7 @@ import com.threegap.bitnagil.presentation.routinelist.model.RoutineListState
 import com.threegap.bitnagil.presentation.routinelist.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -43,7 +43,7 @@ class RoutineListViewModel @Inject constructor(
         observeRoutineChanges()
     }
 
-    override suspend fun SimpleSyntax<RoutineListState, RoutineListSideEffect>.reduceState(
+    override suspend fun Syntax<RoutineListState, RoutineListSideEffect>.reduceState(
         intent: RoutineListIntent,
         state: RoutineListState,
     ): RoutineListState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/setting/SettingViewModel.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,7 +25,7 @@ class SettingViewModel @Inject constructor(
     private var setServiceAlarmJob: Job? = null
     private var setPushAlarmJob: Job? = null
 
-    override suspend fun SimpleSyntax<SettingState, SettingSideEffect>.reduceState(
+    override suspend fun Syntax<SettingState, SettingSideEffect>.reduceState(
         intent: SettingIntent,
         state: SettingState,
     ): SettingState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/splash/SplashViewModel.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,7 +30,7 @@ class SplashViewModel @Inject constructor(
         performForceUpdateCheck()
     }
 
-    override suspend fun SimpleSyntax<SplashState, SplashSideEffect>.reduceState(
+    override suspend fun Syntax<SplashState, SplashSideEffect>.reduceState(
         intent: SplashIntent,
         state: SplashState,
     ): SplashState? =

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/terms/TermsAgreementViewModel.kt
@@ -11,7 +11,7 @@ import com.threegap.bitnagil.presentation.terms.model.TermsAgreementSideEffect
 import com.threegap.bitnagil.presentation.terms.model.TermsAgreementState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,7 +22,7 @@ class TermsAgreementViewModel @Inject constructor(
     initState = TermsAgreementState(),
     savedStateHandle = savedStateHandle,
 ) {
-    override suspend fun SimpleSyntax<TermsAgreementState, TermsAgreementSideEffect>.reduceState(
+    override suspend fun Syntax<TermsAgreementState, TermsAgreementSideEffect>.reduceState(
         intent: TermsAgreementIntent,
         state: TermsAgreementState,
     ): TermsAgreementState? = when (intent) {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/withdrawal/WithdrawalViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/withdrawal/WithdrawalViewModel.kt
@@ -9,7 +9,7 @@ import com.threegap.bitnagil.presentation.withdrawal.model.WithdrawalSideEffect
 import com.threegap.bitnagil.presentation.withdrawal.model.WithdrawalState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,7 +20,7 @@ class WithdrawalViewModel @Inject constructor(
     savedStateHandle = savedStateHandle,
     initState = WithdrawalState(),
 ) {
-    override suspend fun SimpleSyntax<WithdrawalState, WithdrawalSideEffect>.reduceState(
+    override suspend fun Syntax<WithdrawalState, WithdrawalSideEffect>.reduceState(
         intent: WithdrawalIntent,
         state: WithdrawalState,
     ): WithdrawalState? {

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
@@ -25,7 +25,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 
 @HiltViewModel(assistedFactory = WriteRoutineViewModel.Factory::class)
 class WriteRoutineViewModel @AssistedInject constructor(
@@ -133,7 +133,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
         }
     }
 
-    override suspend fun SimpleSyntax<WriteRoutineState, WriteRoutineSideEffect>.reduceState(
+    override suspend fun Syntax<WriteRoutineState, WriteRoutineSideEffect>.reduceState(
         intent: WriteRoutineIntent,
         state: WriteRoutineState,
     ): WriteRoutineState? {

--- a/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
+++ b/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.junit.Before
 import org.junit.Test
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.test.test
 
 @ExperimentalCoroutinesApi
@@ -56,7 +56,7 @@ class MviViewModelTest {
         initState: SampleState,
         savedStateHandle: SavedStateHandle,
     ) : MviViewModel<SampleState, SampleSideEffect, SampleIntent>(initState, savedStateHandle) {
-        override suspend fun SimpleSyntax<SampleState, SampleSideEffect>.reduceState(
+        override suspend fun Syntax<SampleState, SampleSideEffect>.reduceState(
             intent: SampleIntent,
             state: SampleState,
         ): SampleState? {

--- a/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
+++ b/presentation/src/test/java/com/threegap/bitnagil/presentation/common/mviviewmodel/MviViewModelTest.kt
@@ -26,7 +26,6 @@ class MviViewModelTest {
                 containerHost.sendIntent(SampleIntent.Decrease(number = 2))
                 containerHost.sendIntent(SampleIntent.Increase(number = 3))
 
-                expectState { SampleState() }
                 expectState { SampleState(count = 1) }
                 expectState { SampleState(count = -1) }
                 expectState { SampleState(count = 2) }
@@ -42,7 +41,6 @@ class MviViewModelTest {
                 containerHost.sendIntent(SampleIntent.Decrease(number = 2))
                 containerHost.sendIntent(SampleIntent.Increase(number = 3))
 
-                expectState { SampleState() }
                 expectState { SampleState(count = 1) }
                 expectSideEffect(SampleSideEffect.ShowToast("Clear"))
                 expectState { SampleState() }


### PR DESCRIPTION
# [ PR Content ]
orbit-mvi 라이브러리 버전 업 작업을 진행했습니다. (v6.1 -> v10.0)  

주요 변경사항은 다음과 같습니다.
- `intent {}`에서 사용중이던 `runBlocking`이 제거되었습니다 -> [pr 링크](https://github.com/orbit-mvi/orbit-mvi/pull/263/files)
- `SimpleSyntax` -> `Syntax` 로 마이그레이션 되었습니다.
- 이외 자세한 사항은 해당 링크를 참고하면 좋을거 같습니다. -> [릴리즈 링크](https://github.com/orbit-mvi/orbit-mvi/releases)

## Related issue
- closed #134 

## Work Description
- 버전 업 변경사항 대응

## To Reviewers 📢
[추상화에 대한 고찰: orbit MVI의 장점을 활용하지 못하고 있는 이유]
이번 작업을 진행하면서 저희 프로젝트의 orbit mvi 사용 방식에 대해 고민을 해봤습니다.

저희는 mvi 패턴의 "상태 변경 추적의 용이성"의 이점을 누리되, "보일러플레이트 코드 생성"이란 단점을 최소화하기 위해 orbit mvi를 도입했습니다.
하지만 프로젝트의 완성도가 높아진 현시점에서 "과연 보일러플레이트가 줄었는가?"를 생각했을때, 아니다란 생각이 들었습니다. 실제로 수동으로 mvi 패턴을 구현했던 이전 경험과 비교해봐도 orbit을 사용한 코드가 더 간결하다고 느끼기 어려웠습니다.
원인이 무엇일까? 파악을 해봤는데, 저희는 orbit이 제공하는 `intent {}`를 직접 사용하는 것이 아니라, 초기에 라이브러리 교체 용이성을 목적으로 만든 별도의 추상화 계층(`MVIViewModel`, `sendIntent`)을 한 단계 더 통과하고 있습니다. 이 과정에서 intent 객체를 추가로 생성하고 있기 때문에 orbit에서 제거한 보일러플레이트가 다시 발생하고 있었습니다.
이에 대한 해결책을 고민해봤을때, 가능성이 낮은 미래를 고려한 추상화 유지하기 보단 현재의 추상화를 걷어내고 orbit의 장점을 극대화하는 것이 더 얻을 수 있는 이점이 많다고 생각했습니다..!
이에 대한 세환님 의견이 궁금합니다! (어푸 여부와 상관없이, 해당 pr에 남겨주셔도 좋고, 스크럼시간에 다뤄도 좋을거 같습니다!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * Orbit 라이브러리 버전을 10.0.0으로 업데이트했습니다.

* **Refactor**
  * 여러 뷰모델의 Orbit MVI 구문을 최신형으로 일괄 전환했습니다.
  * 관련 임포트와 함수 시그니처를 일관성 있게 정리했습니다.

* **Tests**
  * MVI 관련 테스트를 최신 구문에 맞춰 업데이트하고 일부 초기 상태 기대를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->