### PR TITLE
[Feature/#143] 현재 위치 기반 주소 조회 기능을 구현합니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,17 @@ android {
             name = "KAKAO_NATIVE_APP_KEY",
             value = "\"$kakaoNativeAppKey\"",
         )
+
+        val kakaoRestApiKey =
+            (properties["kakao.rest.api.key"] as? String)
+                ?: System.getenv("KAKAO_REST_API_KEY")
+                ?: throw GradleException("KAKAO_REST_API_KEY 값이 없습니다.")
+
+        buildConfigField(
+            type = "String",
+            name = "KAKAO_REST_API_KEY",
+            value = "\"$kakaoRestApiKey\"",
+        )
     }
 
     buildTypes {

--- a/app/src/main/java/com/threegap/bitnagil/di/core/NetworkModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/core/NetworkModule.kt
@@ -30,6 +30,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
     private const val APPLICATION_JSON = "application/json"
+    private const val REST_API_KEY = BuildConfig.KAKAO_REST_API_KEY
+    private const val KAKAO_URL = "https://dapi.kakao.com"
 
     @Provides
     @Singleton
@@ -73,6 +75,43 @@ object NetworkModule {
 
             override suspend fun clearTokens() = dataStore.clearAuthToken()
         }
+
+    @Provides
+    @Singleton
+    @Kakao
+    fun provideKakaoAuthInterceptor(): Interceptor =
+        Interceptor { chain ->
+            val request = chain.request().newBuilder()
+                .addHeader("Authorization", "KakaoAK $REST_API_KEY")
+                .build()
+            chain.proceed(request)
+        }
+
+    @Provides
+    @Singleton
+    @Kakao
+    fun provideKakaoOkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+        @Kakao kakaoAuthInterceptor: Interceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(kakaoAuthInterceptor)
+        .addInterceptor(httpLoggingInterceptor)
+        .connectTimeout(10L, TimeUnit.SECONDS)
+        .writeTimeout(30L, TimeUnit.SECONDS)
+        .readTimeout(30L, TimeUnit.SECONDS)
+        .build()
+
+    @Provides
+    @Singleton
+    @Kakao
+    fun provideKakaoRetrofit(
+        converterFactory: Converter.Factory,
+        @Kakao okHttpClient: OkHttpClient,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(KAKAO_URL)
+        .addConverterFactory(converterFactory)
+        .client(okHttpClient)
+        .build()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/threegap/bitnagil/di/core/Qualifier.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/core/Qualifier.kt
@@ -9,3 +9,7 @@ annotation class NoneAuth
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class Auth
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Kakao

--- a/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/DataSourceModule.kt
@@ -1,5 +1,9 @@
 package com.threegap.bitnagil.di.data
 
+import com.threegap.bitnagil.data.address.datasource.AddressDataSource
+import com.threegap.bitnagil.data.address.datasource.LocationDataSource
+import com.threegap.bitnagil.data.address.datasourceImpl.AddressDataSourceImpl
+import com.threegap.bitnagil.data.address.datasourceImpl.LocationDataSourceImpl
 import com.threegap.bitnagil.data.auth.datasource.AuthLocalDataSource
 import com.threegap.bitnagil.data.auth.datasource.AuthRemoteDataSource
 import com.threegap.bitnagil.data.auth.datasourceimpl.AuthLocalDataSourceImpl
@@ -63,4 +67,12 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindVersionDataSource(versionDataSourceImpl: VersionDataSourceImpl): VersionDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindLocationDataSource(locationDataSourceImpl: LocationDataSourceImpl): LocationDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindAddressDataSource(addressDataSourceImpl: AddressDataSourceImpl): AddressDataSource
 }

--- a/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.threegap.bitnagil.di.data
 
+import com.threegap.bitnagil.data.address.repositoryImpl.AddressRepositoryImpl
 import com.threegap.bitnagil.data.auth.repositoryimpl.AuthRepositoryImpl
 import com.threegap.bitnagil.data.emotion.repositoryImpl.EmotionRepositoryImpl
 import com.threegap.bitnagil.data.onboarding.repositoryImpl.OnBoardingRepositoryImpl
@@ -8,6 +9,7 @@ import com.threegap.bitnagil.data.routine.repositoryImpl.RoutineRepositoryImpl
 import com.threegap.bitnagil.data.user.repositoryImpl.UserRepositoryImpl
 import com.threegap.bitnagil.data.version.repositoryImpl.VersionRepositoryImpl
 import com.threegap.bitnagil.data.writeroutine.repositoryImpl.WriteRoutineRepositoryImpl
+import com.threegap.bitnagil.domain.address.repository.AddressRepository
 import com.threegap.bitnagil.domain.auth.repository.AuthRepository
 import com.threegap.bitnagil.domain.emotion.repository.EmotionRepository
 import com.threegap.bitnagil.domain.onboarding.repository.OnBoardingRepository
@@ -57,4 +59,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindVersionRepository(versionRepositoryImpl: VersionRepositoryImpl): VersionRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAddressRepository(addressRepositoryImpl: AddressRepositoryImpl): AddressRepository
 }

--- a/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.threegap.bitnagil.di.data
 
+import com.threegap.bitnagil.data.address.service.AddressService
 import com.threegap.bitnagil.data.auth.service.AuthService
 import com.threegap.bitnagil.data.emotion.service.EmotionService
 import com.threegap.bitnagil.data.onboarding.service.OnBoardingService
@@ -9,6 +10,7 @@ import com.threegap.bitnagil.data.user.service.UserService
 import com.threegap.bitnagil.data.version.service.VersionService
 import com.threegap.bitnagil.data.writeroutine.service.WriteRoutineService
 import com.threegap.bitnagil.di.core.Auth
+import com.threegap.bitnagil.di.core.Kakao
 import com.threegap.bitnagil.di.core.NoneAuth
 import com.threegap.bitnagil.network.token.ReissueService
 import dagger.Module
@@ -66,4 +68,9 @@ object ServiceModule {
     @Singleton
     fun provideVersionService(@NoneAuth retrofit: Retrofit): VersionService =
         retrofit.create(VersionService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideAddressService(@Kakao retrofit: Retrofit): AddressService =
+        retrofit.create(AddressService::class.java)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -18,4 +18,6 @@ dependencies {
     implementation(libs.bundles.okhttp)
     implementation(platform(libs.retrofit.bom))
     implementation(libs.bundles.retrofit)
+    implementation(libs.play.services.location)
+    implementation(libs.kotlinx.coroutines.play)
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/address/datasource/AddressDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/datasource/AddressDataSource.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.data.address.datasource
+
+import com.threegap.bitnagil.data.address.model.response.Coord2AddressResponse
+
+interface AddressDataSource {
+    suspend fun fetchCurrentAddress(longitude: Double, latitude: Double): Result<Coord2AddressResponse>
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/datasource/LocationDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/datasource/LocationDataSource.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.data.address.datasource
+
+import com.threegap.bitnagil.domain.address.model.CurrentLocation
+
+interface LocationDataSource {
+    suspend fun fetchCurrentLocation(): Result<CurrentLocation>
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/datasourceImpl/AddressDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/datasourceImpl/AddressDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.threegap.bitnagil.data.address.datasourceImpl
+
+import com.threegap.bitnagil.data.address.datasource.AddressDataSource
+import com.threegap.bitnagil.data.address.model.response.Coord2AddressResponse
+import com.threegap.bitnagil.data.address.service.AddressService
+import javax.inject.Inject
+
+class AddressDataSourceImpl @Inject constructor(
+    private val addressService: AddressService,
+) : AddressDataSource {
+
+    override suspend fun fetchCurrentAddress(longitude: Double, latitude: Double): Result<Coord2AddressResponse> {
+        return runCatching {
+            addressService.fetchCurrentAddress(
+                longitude = longitude.toString(),
+                latitude = latitude.toString(),
+            )
+        }
+    }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/datasourceImpl/LocationDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/datasourceImpl/LocationDataSourceImpl.kt
@@ -1,0 +1,23 @@
+package com.threegap.bitnagil.data.address.datasourceImpl
+
+import android.annotation.SuppressLint
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.threegap.bitnagil.data.address.datasource.LocationDataSource
+import com.threegap.bitnagil.domain.address.model.CurrentLocation
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class LocationDataSourceImpl @Inject constructor(
+    private val fusedLocationClient: FusedLocationProviderClient,
+) : LocationDataSource {
+
+    @SuppressLint("MissingPermission")
+    override suspend fun fetchCurrentLocation(): Result<CurrentLocation> {
+        return runCatching {
+            val location = fusedLocationClient.lastLocation.await()
+                ?: throw Exception("Location not available")
+
+            CurrentLocation(latitude = location.latitude, longitude = location.longitude)
+        }
+    }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/di/LocationModule.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/di/LocationModule.kt
@@ -1,0 +1,21 @@
+package com.threegap.bitnagil.data.address.di
+
+import android.content.Context
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocationModule {
+
+    @Provides
+    @Singleton
+    fun provideFusedLocationProviderClient(@ApplicationContext context: Context): FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
@@ -1,0 +1,75 @@
+package com.threegap.bitnagil.data.address.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Coord2AddressResponse(
+    @SerialName("meta")
+    val meta: Meta,
+    @SerialName("documents")
+    val documents: List<Document>,
+)
+
+@Serializable
+data class Meta(
+    @SerialName("total_count")
+    val totalCount: Int,
+)
+
+@Serializable
+data class Document(
+    @SerialName("road_address")
+    val roadAddress: RoadAddress,
+    @SerialName("address")
+    val address: Address,
+)
+
+@Serializable
+data class Address(
+    @SerialName("address_name")
+    val addressName: String,
+    @SerialName("region_1depth_name")
+    val region1depthName: String,
+    @SerialName("region_2depth_name")
+    val region2depthName: String,
+    @SerialName("region_3depth_name")
+    val region3depthName: String,
+    @SerialName("mountain_yn")
+    val mountainYn: String,
+    @SerialName("main_address_no")
+    val mainAddressNo: String,
+    @SerialName("sub_address_no")
+    val subAddressNo: String,
+)
+
+@Serializable
+data class RoadAddress(
+    @SerialName("address_name")
+    val addressName: String,
+    @SerialName("region_1depth_name")
+    val region1depthName: String,
+    @SerialName("region_2depth_name")
+    val region2depthName: String,
+    @SerialName("region_3depth_name")
+    val region3depthName: String,
+    @SerialName("road_name")
+    val roadName: String,
+    @SerialName("underground_yn")
+    val undergroundYn: String,
+    @SerialName("main_building_no")
+    val mainBuildingNo: String,
+    @SerialName("sub_building_no")
+    val subBuildingNo: String,
+    @SerialName("building_name")
+    val buildingName: String,
+    @SerialName("zone_no")
+    val zoneNo: String,
+)
+
+fun Coord2AddressResponse.toAddress(): String? {
+    return this.documents
+        .firstOrNull()
+        ?.roadAddress
+        ?.addressName
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/repositoryImpl/AddressRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/repositoryImpl/AddressRepositoryImpl.kt
@@ -16,8 +16,8 @@ class AddressRepositoryImpl @Inject constructor(
         return locationDataSource.fetchCurrentLocation()
     }
 
-    override suspend fun fetchCurrentAddress(latitude: Double, longitude: Double): Result<String> {
-        return addressDataSource.fetchCurrentAddress(latitude, longitude)
+    override suspend fun fetchCurrentAddress(longitude: Double, latitude: Double): Result<String> {
+        return addressDataSource.fetchCurrentAddress(longitude = longitude, latitude = latitude)
             .mapCatching {
                 it.toAddress() ?: throw Exception("Address not found")
             }

--- a/data/src/main/java/com/threegap/bitnagil/data/address/repositoryImpl/AddressRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/repositoryImpl/AddressRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.threegap.bitnagil.data.address.repositoryImpl
+
+import com.threegap.bitnagil.data.address.datasource.AddressDataSource
+import com.threegap.bitnagil.data.address.datasource.LocationDataSource
+import com.threegap.bitnagil.data.address.model.response.toAddress
+import com.threegap.bitnagil.domain.address.model.CurrentLocation
+import com.threegap.bitnagil.domain.address.repository.AddressRepository
+import javax.inject.Inject
+
+class AddressRepositoryImpl @Inject constructor(
+    private val locationDataSource: LocationDataSource,
+    private val addressDataSource: AddressDataSource,
+) : AddressRepository {
+
+    override suspend fun fetchCurrentLocation(): Result<CurrentLocation> {
+        return locationDataSource.fetchCurrentLocation()
+    }
+
+    override suspend fun fetchCurrentAddress(latitude: Double, longitude: Double): Result<String> {
+        return addressDataSource.fetchCurrentAddress(latitude, longitude)
+            .mapCatching {
+                it.toAddress() ?: throw Exception("Address not found")
+            }
+    }
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/address/service/AddressService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/service/AddressService.kt
@@ -1,0 +1,13 @@
+package com.threegap.bitnagil.data.address.service
+
+import com.threegap.bitnagil.data.address.model.response.Coord2AddressResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface AddressService {
+    @GET("/v2/local/geo/coord2address.json")
+    suspend fun fetchCurrentAddress(
+        @Query("x") longitude: String,
+        @Query("y") latitude: String,
+    ): Coord2AddressResponse
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/model/CurrentAddress.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/model/CurrentAddress.kt
@@ -1,0 +1,7 @@
+package com.threegap.bitnagil.domain.address.model
+
+data class CurrentAddress(
+    val latitude: Double,
+    val longitude: Double,
+    val roadAddress: String,
+)

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/model/CurrentLocation.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/model/CurrentLocation.kt
@@ -1,0 +1,6 @@
+package com.threegap.bitnagil.domain.address.model
+
+data class CurrentLocation(
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/repository/AddressRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/repository/AddressRepository.kt
@@ -4,5 +4,5 @@ import com.threegap.bitnagil.domain.address.model.CurrentLocation
 
 interface AddressRepository {
     suspend fun fetchCurrentLocation(): Result<CurrentLocation>
-    suspend fun fetchCurrentAddress(latitude: Double, longitude: Double): Result<String>
+    suspend fun fetchCurrentAddress(longitude: Double, latitude: Double): Result<String>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/repository/AddressRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/repository/AddressRepository.kt
@@ -1,0 +1,8 @@
+package com.threegap.bitnagil.domain.address.repository
+
+import com.threegap.bitnagil.domain.address.model.CurrentLocation
+
+interface AddressRepository {
+    suspend fun fetchCurrentLocation(): Result<CurrentLocation>
+    suspend fun fetchCurrentAddress(latitude: Double, longitude: Double): Result<String>
+}

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/usecase/FetchCurrentAddressUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/usecase/FetchCurrentAddressUseCase.kt
@@ -11,8 +11,8 @@ class FetchCurrentAddressUseCase @Inject constructor(
         return addressRepository.fetchCurrentLocation()
             .mapCatching { location ->
                 val roadAddress = addressRepository.fetchCurrentAddress(
-                    latitude = location.latitude,
                     longitude = location.longitude,
+                    latitude = location.latitude,
                 ).getOrThrow()
 
                 CurrentAddress(

--- a/domain/src/main/java/com/threegap/bitnagil/domain/address/usecase/FetchCurrentAddressUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/address/usecase/FetchCurrentAddressUseCase.kt
@@ -1,0 +1,25 @@
+package com.threegap.bitnagil.domain.address.usecase
+
+import com.threegap.bitnagil.domain.address.model.CurrentAddress
+import com.threegap.bitnagil.domain.address.repository.AddressRepository
+import javax.inject.Inject
+
+class FetchCurrentAddressUseCase @Inject constructor(
+    private val addressRepository: AddressRepository,
+) {
+    suspend operator fun invoke(): Result<CurrentAddress> {
+        return addressRepository.fetchCurrentLocation()
+            .mapCatching { location ->
+                val roadAddress = addressRepository.fetchCurrentAddress(
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                ).getOrThrow()
+
+                CurrentAddress(
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                    roadAddress = roadAddress,
+                )
+            }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ kakaoLogin = "2.21.4"
 lottie-compose = "6.6.0"
 coil = "3.3.0"
 accompanist = "0.37.3"
+playServicesLocation = "21.3.0"
 
 [libraries]
 ## Android Gradle Plugin
@@ -90,6 +91,7 @@ compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4
 ## Kotlin
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-play = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 ## Hilt
@@ -129,6 +131,8 @@ kakao-v2-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kaka
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie-compose" }
 
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+
 
 [bundles]
 androidx-core = [

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.bundles.coil)
     implementation(libs.accompanist.permissions)
+    implementation(libs.play.services.location)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.coroutines.test)

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.bundles.coil)
     implementation(libs.accompanist.permissions)
-    implementation(libs.play.services.location)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.coroutines.test)

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
@@ -2,6 +2,7 @@ package com.threegap.bitnagil.presentation.report
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import com.threegap.bitnagil.domain.address.usecase.FetchCurrentAddressUseCase
 import com.threegap.bitnagil.presentation.report.model.ReportCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
@@ -10,7 +11,9 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
-class ReportViewModel @Inject constructor() : ViewModel(), ContainerHost<ReportState, ReportSideEffect> {
+class ReportViewModel @Inject constructor(
+    private val fetchCurrentAddressUseCase: FetchCurrentAddressUseCase,
+) : ViewModel(), ContainerHost<ReportState, ReportSideEffect> {
 
     override val container: Container<ReportState, ReportSideEffect> = container(initialState = ReportState.Init)
 
@@ -57,7 +60,20 @@ class ReportViewModel @Inject constructor() : ViewModel(), ContainerHost<ReportS
     }
 
     fun fetchCurrentAddress() {
-        // TODO
+        intent {
+            fetchCurrentAddressUseCase().fold(
+                onSuccess = {
+                    reduce {
+                        state.copy(
+                            currentLatitude = it.latitude,
+                            currentLongitude = it.longitude,
+                            currentAddress = it.roadAddress,
+                        )
+                    }
+                },
+                onFailure = {},
+            )
+        }
     }
 
     fun addImages(uris: List<Uri>) {


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
제보하기 화면에서 사용자의 현재 위치를 기반으로 도로명 주소를 조회하는 기능을 구현했습니다.
대략적인 flow는 다음과 같습니다. [위도,경도 획득 → Kakao 좌표-주소 변환 API 호출 → 도메인 모델 변환]

## Related issue
- closed #143 

## Screenshot 📸

https://github.com/user-attachments/assets/b324072c-50a1-4b55-806b-4ca1914fdfe4


## Work Description
- 내 위치 호출 기능 구현(위도, 경도)
- kakao 좌표 -> 주소 변환 api 기능 구현
  - 현재 내 위치(위도,경도)를 기반으로 도로명 주소를 받아옵니다.

## To Reviewers 📢
- 로컬 프로퍼티에 KAKAO_REST_API_KEY 값 추가 부탁드립니다! (컨플문서 확인해주세요)
- 주소의 경우 현재 내 위치(위도,경도)기반으로 카카오api를 활용해서 도로명 주소를 받아오도록 구현했습니다.
  - 카카오 디벨로퍼 docs [kakao](https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address)
  - 엣지 케이스: 올바르지 않은 위도 경도(ex. 미국)인 경우 
  -> 주소를 반환 x, 하지만 제보 도메인을 고려했을때 한국만 가능하기에 문제가 없다고 생각됩니다. (추후 기획적으로 토스트메시지 제공 등의 논의 필요)
