### PR TITLE
[FIX/#152] 주소 변환 시 도로명 주소가 null인 문제를 해결합니다.

### DIFF
--- a/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
@@ -70,6 +70,6 @@ data class RoadAddress(
 fun Coord2AddressResponse.toAddress(): String? {
     return this.documents
         .firstOrNull()
-        ?.roadAddress
+        ?.address
         ?.addressName
 }


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## Related issue
- closed #152 

## Screenshot 📸

<img width="835" height="117" alt="스크린샷 2025-11-22 22 55 24" src="https://github.com/user-attachments/assets/959accc8-2219-4d1f-8f62-36879b1ab7ec" />

## Work Description
- 도로명 주소 -> 지번 주소로 변경

## To Reviewers 📢
- api 문서를 읽어보니 도로명 주소는 null 값이 오는 경우가 있다고 하더군요,,,! 해서 안전하게 지번주소를 사용하도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 좌표에서 주소로 변환하는 기능에서 주소 정보 추출 방식을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->