### PR TITLE
[Feature/#154] 제보 상세조회 화면 구현

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
@@ -14,6 +14,9 @@ import com.threegap.bitnagil.presentation.onboarding.OnBoardingScreenContainer
 import com.threegap.bitnagil.presentation.onboarding.OnBoardingViewModel
 import com.threegap.bitnagil.presentation.onboarding.model.navarg.OnBoardingScreenArg
 import com.threegap.bitnagil.presentation.report.ReportScreenContainer
+import com.threegap.bitnagil.presentation.reportdetail.ReportDetailScreenContainer
+import com.threegap.bitnagil.presentation.reportdetail.ReportDetailViewModel
+import com.threegap.bitnagil.presentation.reportdetail.model.navarg.ReportDetailScreenArg
 import com.threegap.bitnagil.presentation.reporthistory.ReportHistoryScreenContainer
 import com.threegap.bitnagil.presentation.routinelist.RoutineListScreenContainer
 import com.threegap.bitnagil.presentation.setting.SettingScreenContainer
@@ -319,7 +322,27 @@ fun MainNavHost(
                         navigator.navController.popBackStack()
                     }
                 },
-                navigateToReportDetail = {
+                navigateToReportDetail = { reportId ->
+                    navigator.navController.navigate(Route.ReportDetail(reportId = reportId)) {
+                        launchSingleTop = true
+                    }
+                },
+            )
+        }
+
+        composable<Route.ReportDetail> { navBackStackEntry ->
+            val arg = navBackStackEntry.toRoute<Route.ReportDetail>()
+            val reportDetailScreenArg = ReportDetailScreenArg(reportId = arg.reportId)
+            val viewModel = hiltViewModel<ReportDetailViewModel, ReportDetailViewModel.Factory> { factory ->
+                factory.create(reportDetailScreenArg)
+            }
+
+            ReportDetailScreenContainer(
+                viewModel = viewModel,
+                navigateToBack = {
+                    if (navigator.navController.previousBackStackEntry != null) {
+                        navigator.navController.popBackStack()
+                    }
                 },
             )
         }

--- a/app/src/main/java/com/threegap/bitnagil/Route.kt
+++ b/app/src/main/java/com/threegap/bitnagil/Route.kt
@@ -54,4 +54,7 @@ sealed interface Route {
 
     @Serializable
     data object ReportHistory : Route
+
+    @Serializable
+    data class ReportDetail(val reportId: String) : Route
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/address/model/response/Coord2AddressResponse.kt
@@ -20,7 +20,7 @@ data class Meta(
 @Serializable
 data class Document(
     @SerialName("road_address")
-    val roadAddress: RoadAddress,
+    val roadAddress: RoadAddress?,
     @SerialName("address")
     val address: Address,
 )

--- a/data/src/main/java/com/threegap/bitnagil/data/report/datasource/ReportDataSource.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/report/datasource/ReportDataSource.kt
@@ -1,9 +1,11 @@
 package com.threegap.bitnagil.data.report.datasource
 
 import com.threegap.bitnagil.data.report.model.request.ReportRequestDto
+import com.threegap.bitnagil.data.report.model.response.ReportDetailDto
 import com.threegap.bitnagil.data.report.model.response.ReportHistoriesPerDateDto
 
 interface ReportDataSource {
     suspend fun submitReport(reportRequestDto: ReportRequestDto): Result<Long>
     suspend fun getReports(): Result<ReportHistoriesPerDateDto>
+    suspend fun getReport(reportId: String): Result<ReportDetailDto>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/report/datasourceImpl/ReportDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/report/datasourceImpl/ReportDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.threegap.bitnagil.data.report.datasourceImpl
 import com.threegap.bitnagil.data.common.safeApiCall
 import com.threegap.bitnagil.data.report.datasource.ReportDataSource
 import com.threegap.bitnagil.data.report.model.request.ReportRequestDto
+import com.threegap.bitnagil.data.report.model.response.ReportDetailDto
 import com.threegap.bitnagil.data.report.model.response.ReportHistoriesPerDateDto
 import com.threegap.bitnagil.data.report.service.ReportService
 import javax.inject.Inject
@@ -16,5 +17,9 @@ class ReportDataSourceImpl @Inject constructor(
 
     override suspend fun getReports(): Result<ReportHistoriesPerDateDto> {
         return safeApiCall { reportService.getReports() }
+    }
+
+    override suspend fun getReport(reportId: String): Result<ReportDetailDto> {
+        return safeApiCall { reportService.getReport(reportId = reportId) }
     }
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/report/model/response/ReportDetailDto.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/report/model/response/ReportDetailDto.kt
@@ -1,0 +1,38 @@
+package com.threegap.bitnagil.data.report.model.response
+
+import com.threegap.bitnagil.domain.report.model.ReportCategory
+import com.threegap.bitnagil.domain.report.model.ReportDetail
+import com.threegap.bitnagil.domain.report.model.ReportStatus
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+@Serializable
+class ReportDetailDto(
+    @SerialName("reportDate")
+    val reportDate: String,
+    @SerialName("reportStatus")
+    val reportStatus: String,
+    @SerialName("reportTitle")
+    val reportTitle: String,
+    @SerialName("reportContent")
+    val reportContent: String,
+    @SerialName("reportCategory")
+    val reportCategory: String,
+    @SerialName("reportLocation")
+    val reportLocation: String,
+    @SerialName("reportImageUrls")
+    val reportImageUrls: List<String>,
+)
+
+fun ReportDetailDto.toDomain(id: String?): ReportDetail =
+    ReportDetail(
+        id = id ?: "",
+        date = LocalDate.parse(this.reportDate),
+        status = ReportStatus.fromString(this.reportStatus),
+        title = this.reportTitle,
+        content = this.reportContent,
+        category = ReportCategory.fromString(this.reportCategory),
+        address = this.reportLocation,
+        imageUrls = this.reportImageUrls,
+    )

--- a/data/src/main/java/com/threegap/bitnagil/data/report/repositoryImpl/ReportRepositoryImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/report/repositoryImpl/ReportRepositoryImpl.kt
@@ -2,8 +2,10 @@ package com.threegap.bitnagil.data.report.repositoryImpl
 
 import com.threegap.bitnagil.data.report.datasource.ReportDataSource
 import com.threegap.bitnagil.data.report.model.request.toDto
+import com.threegap.bitnagil.data.report.model.response.toDomain
 import com.threegap.bitnagil.data.report.model.response.toDomainMap
 import com.threegap.bitnagil.domain.report.model.Report
+import com.threegap.bitnagil.domain.report.model.ReportDetail
 import com.threegap.bitnagil.domain.report.model.ReportItem
 import com.threegap.bitnagil.domain.report.repository.ReportRepository
 import java.time.LocalDate
@@ -18,5 +20,9 @@ class ReportRepositoryImpl @Inject constructor(
 
     override suspend fun getReportHistories(): Result<Map<LocalDate, List<ReportItem>>> {
         return reportDataSource.getReports().map { it.toDomainMap() }
+    }
+
+    override suspend fun getReport(reportId: String): Result<ReportDetail> {
+        return reportDataSource.getReport(reportId = reportId).map { it.toDomain(id = reportId) }
     }
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/report/service/ReportService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/report/service/ReportService.kt
@@ -1,11 +1,13 @@
 package com.threegap.bitnagil.data.report.service
 
 import com.threegap.bitnagil.data.report.model.request.ReportRequestDto
+import com.threegap.bitnagil.data.report.model.response.ReportDetailDto
 import com.threegap.bitnagil.data.report.model.response.ReportHistoriesPerDateDto
 import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface ReportService {
     @POST("/api/v2/reports")
@@ -15,4 +17,9 @@ interface ReportService {
 
     @GET("/api/v2/reports")
     suspend fun getReports(): BaseResponse<ReportHistoriesPerDateDto>
+
+    @GET("/api/v2/reports/{reportId}")
+    suspend fun getReport(
+        @Path("reportId") reportId: String,
+    ): BaseResponse<ReportDetailDto>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/report/model/ReportDetail.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/report/model/ReportDetail.kt
@@ -1,0 +1,14 @@
+package com.threegap.bitnagil.domain.report.model
+
+import java.time.LocalDate
+
+data class ReportDetail(
+    val id: String,
+    val title: String,
+    val content: String,
+    val category: ReportCategory,
+    val status: ReportStatus,
+    val imageUrls: List<String>,
+    val address: String,
+    val date: LocalDate,
+)

--- a/domain/src/main/java/com/threegap/bitnagil/domain/report/repository/ReportRepository.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/report/repository/ReportRepository.kt
@@ -1,10 +1,12 @@
 package com.threegap.bitnagil.domain.report.repository
 
 import com.threegap.bitnagil.domain.report.model.Report
+import com.threegap.bitnagil.domain.report.model.ReportDetail
 import com.threegap.bitnagil.domain.report.model.ReportItem
 import java.time.LocalDate
 
 interface ReportRepository {
     suspend fun submitReport(report: Report): Result<Long>
     suspend fun getReportHistories(): Result<Map<LocalDate, List<ReportItem>>>
+    suspend fun getReport(reportId: String): Result<ReportDetail>
 }

--- a/domain/src/main/java/com/threegap/bitnagil/domain/report/usecase/GetReportUseCase.kt
+++ b/domain/src/main/java/com/threegap/bitnagil/domain/report/usecase/GetReportUseCase.kt
@@ -1,0 +1,13 @@
+package com.threegap.bitnagil.domain.report.usecase
+
+import com.threegap.bitnagil.domain.report.model.ReportDetail
+import com.threegap.bitnagil.domain.report.repository.ReportRepository
+import javax.inject.Inject
+
+class GetReportUseCase @Inject constructor(
+    private val reportRepository: ReportRepository,
+) {
+    suspend operator fun invoke(id: String): Result<ReportDetail> {
+        return reportRepository.getReport(reportId = id)
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,12 +31,19 @@ import com.threegap.bitnagil.presentation.reportdetail.component.atom.ReportProc
 import com.threegap.bitnagil.presentation.reportdetail.component.block.ReportDetailLabeledContent
 import com.threegap.bitnagil.presentation.reportdetail.model.mvi.ReportDetailState
 import com.threegap.bitnagil.presentation.reportdetail.util.toPresentationFormatInReportDetail
+import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
 fun ReportDetailScreenContainer(
-
+    viewModel: ReportDetailViewModel,
+    navigateToBack: () -> Unit,
 ) {
+    val state by viewModel.collectAsState()
 
+    ReportDetailScreen(
+        state = state,
+        onClickPreviousButton = navigateToBack,
+    )
 }
 
 @Composable
@@ -82,6 +91,7 @@ private fun ReportDetailScreen(
                         .size(74.dp)
                         .clip(shape = RoundedCornerShape(9.dp))
                         .background(color = BitnagilTheme.colors.black),
+                    contentScale = ContentScale.Crop,
                     contentDescription = null,
                 )
             }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
@@ -1,0 +1,135 @@
+package com.threegap.bitnagil.presentation.reportdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.designsystem.component.block.BitnagilTopBar
+import com.threegap.bitnagil.presentation.reportdetail.component.atom.ReportProcessBadge
+import com.threegap.bitnagil.presentation.reportdetail.component.block.ReportDetailLabeledContent
+import com.threegap.bitnagil.presentation.reportdetail.model.mvi.ReportDetailState
+import com.threegap.bitnagil.presentation.reportdetail.util.toPresentationFormatInReportDetail
+
+@Composable
+fun ReportDetailScreenContainer(
+
+) {
+
+}
+
+@Composable
+private fun ReportDetailScreen(
+    modifier: Modifier = Modifier,
+    onClickPreviousButton: () -> Unit,
+    state: ReportDetailState,
+) {
+    val verticalScrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(verticalScrollState)
+            .background(color = BitnagilTheme.colors.white)
+            .statusBarsPadding()
+            .padding(horizontal = 20.dp),
+    ) {
+        BitnagilTopBar(
+            title = "제보하기",
+            showBackButton = true,
+            onBackClick = onClickPreviousButton,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        ReportProcessBadge(reportProcess = state.reportProcess)
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = state.date.toPresentationFormatInReportDetail(),
+            style = BitnagilTheme.typography.subtitle1SemiBold,
+        )
+
+        Spacer(modifier = Modifier.height(14.dp))
+
+        Row {
+            state.imageUrls.forEach { imageUrl ->
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(imageUrl)
+                        .build(),
+                    modifier = Modifier
+                        .size(74.dp)
+                        .clip(shape = RoundedCornerShape(9.dp))
+                        .background(color = BitnagilTheme.colors.black),
+                    contentDescription = null,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(28.dp),
+        ) {
+            ReportDetailLabeledContent(
+                label = "제목",
+                content = state.reportTitle,
+            )
+
+            ReportDetailLabeledContent(
+                label = "카테고리",
+                content = state.reportCategory.title,
+            )
+
+            ReportDetailLabeledContent(
+                label = "상세 제목 내용",
+                content = state.reportContent,
+            )
+
+            ReportDetailLabeledContent(
+                label = "내 위치",
+                content = state.location,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(36.dp))
+    }
+}
+
+@Composable
+@Preview
+private fun ReportDetailScreenPreview() {
+    BitnagilTheme {
+        ReportDetailScreen(
+            state = ReportDetailState.Init.copy(
+                reportContent = "Lorem ipsum dolor sit amet, " +
+                    "consectetur adipiscing elit," +
+                    " sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                    "Nisl tincidunt eget nullam non.",
+            ),
+            onClickPreviousButton = {},
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
@@ -57,10 +57,8 @@ private fun ReportDetailScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(verticalScrollState)
             .background(color = BitnagilTheme.colors.white)
-            .statusBarsPadding()
-            .padding(horizontal = 20.dp),
+            .statusBarsPadding(),
     ) {
         BitnagilTopBar(
             title = "제보하기",
@@ -68,63 +66,70 @@ private fun ReportDetailScreen(
             onBackClick = onClickPreviousButton,
         )
 
-        Spacer(modifier = Modifier.height(20.dp))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(verticalScrollState)
+                .padding(horizontal = 20.dp),
+        ) {
+            Spacer(modifier = Modifier.height(20.dp))
 
-        ReportProcessBadge(reportProcess = state.reportProcess)
+            ReportProcessBadge(reportProcess = state.reportProcess)
 
-        Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(6.dp))
 
-        Text(
-            text = state.date.toPresentationFormatInReportDetail(),
-            style = BitnagilTheme.typography.subtitle1SemiBold,
-        )
+            Text(
+                text = state.date.toPresentationFormatInReportDetail(),
+                style = BitnagilTheme.typography.subtitle1SemiBold,
+            )
 
-        Spacer(modifier = Modifier.height(14.dp))
+            Spacer(modifier = Modifier.height(14.dp))
 
-        Row {
-            state.imageUrls.forEach { imageUrl ->
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(imageUrl)
-                        .build(),
-                    modifier = Modifier
-                        .size(74.dp)
-                        .clip(shape = RoundedCornerShape(9.dp))
-                        .background(color = BitnagilTheme.colors.black),
-                    contentScale = ContentScale.Crop,
-                    contentDescription = null,
+            Row {
+                state.imageUrls.forEach { imageUrl ->
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(imageUrl)
+                            .build(),
+                        modifier = Modifier
+                            .size(74.dp)
+                            .clip(shape = RoundedCornerShape(9.dp))
+                            .background(color = BitnagilTheme.colors.black),
+                        contentScale = ContentScale.Crop,
+                        contentDescription = null,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(28.dp),
+            ) {
+                ReportDetailLabeledContent(
+                    label = "제목",
+                    content = state.reportTitle,
+                )
+
+                ReportDetailLabeledContent(
+                    label = "카테고리",
+                    content = state.reportCategory.title,
+                )
+
+                ReportDetailLabeledContent(
+                    label = "상세 제목 내용",
+                    content = state.reportContent,
+                )
+
+                ReportDetailLabeledContent(
+                    label = "내 위치",
+                    content = state.location,
                 )
             }
+
+            Spacer(modifier = Modifier.height(36.dp))
         }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(28.dp),
-        ) {
-            ReportDetailLabeledContent(
-                label = "제목",
-                content = state.reportTitle,
-            )
-
-            ReportDetailLabeledContent(
-                label = "카테고리",
-                content = state.reportCategory.title,
-            )
-
-            ReportDetailLabeledContent(
-                label = "상세 제목 내용",
-                content = state.reportContent,
-            )
-
-            ReportDetailLabeledContent(
-                label = "내 위치",
-                content = state.location,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(36.dp))
     }
 }
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailViewModel.kt
@@ -1,0 +1,53 @@
+package com.threegap.bitnagil.presentation.reportdetail
+
+import androidx.lifecycle.ViewModel
+import com.threegap.bitnagil.domain.report.usecase.GetReportUseCase
+import com.threegap.bitnagil.presentation.reportdetail.model.ReportCategory
+import com.threegap.bitnagil.presentation.reportdetail.model.ReportProcess
+import com.threegap.bitnagil.presentation.reportdetail.model.mvi.ReportDetailSideEffect
+import com.threegap.bitnagil.presentation.reportdetail.model.mvi.ReportDetailState
+import com.threegap.bitnagil.presentation.reportdetail.model.navarg.ReportDetailScreenArg
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
+
+@HiltViewModel(assistedFactory = ReportDetailViewModel.Factory::class)
+class ReportDetailViewModel @AssistedInject constructor(
+    private val getReportDetailUseCase: GetReportUseCase,
+    @Assisted private val reportDetailArg: ReportDetailScreenArg,
+) : ContainerHost<ReportDetailState, ReportDetailSideEffect>, ViewModel() {
+    override val container: Container<ReportDetailState, ReportDetailSideEffect> = container(initialState = ReportDetailState.Init)
+
+    @AssistedFactory
+    interface Factory {
+        fun create(reportDetailArg: ReportDetailScreenArg): ReportDetailViewModel
+    }
+
+    init {
+        loadReportDetail(reportId = reportDetailArg.reportId)
+    }
+
+    private fun loadReportDetail(reportId: String) = intent {
+        getReportDetailUseCase(id = reportId).fold(
+            onSuccess = { reportDetail ->
+                reduce {
+                    state.copy(
+                        reportProcess = ReportProcess.fromDomain(reportDetail.status),
+                        reportTitle = reportDetail.title,
+                        reportContent = reportDetail.content,
+                        reportCategory = ReportCategory.fromDomain(reportDetail.category),
+                        imageUrls = reportDetail.imageUrls,
+                        location = reportDetail.address,
+                        date = reportDetail.date,
+                    )
+                }
+            },
+            onFailure = {
+            },
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/component/atom/ReportProcessBadge.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/component/atom/ReportProcessBadge.kt
@@ -1,0 +1,60 @@
+package com.threegap.bitnagil.presentation.reportdetail.component.atom
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+import com.threegap.bitnagil.presentation.reportdetail.model.ReportProcess
+
+@Composable
+fun ReportProcessBadge(
+    modifier: Modifier = Modifier,
+    reportProcess: ReportProcess,
+) {
+    Text(
+        text = reportProcess.title,
+        style = BitnagilTheme.typography.caption1SemiBold,
+        color = reportProcess.getProcessBadgeTextColor(),
+        modifier = modifier
+            .background(color = reportProcess.getProcessBadgeBackgroundColor(), shape = RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun ReportProcess.getProcessBadgeBackgroundColor(): Color =
+    when (this) {
+        ReportProcess.Reported -> BitnagilTheme.colors.green10
+        ReportProcess.Progress -> BitnagilTheme.colors.skyBlue10
+        else -> BitnagilTheme.colors.coolGray95
+    }
+
+@Composable
+private fun ReportProcess.getProcessBadgeTextColor(): Color =
+    when (this) {
+        ReportProcess.Reported -> BitnagilTheme.colors.green300
+        ReportProcess.Progress -> BitnagilTheme.colors.blue300
+        else -> BitnagilTheme.colors.coolGray40
+    }
+
+@Composable
+@Preview
+private fun ReportProcessBadgePreview() {
+    BitnagilTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            ReportProcessBadge(reportProcess = ReportProcess.Progress)
+            ReportProcessBadge(reportProcess = ReportProcess.Reported)
+            ReportProcessBadge(reportProcess = ReportProcess.Complete)
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/component/block/ReportDetailLabeledContent.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/component/block/ReportDetailLabeledContent.kt
@@ -1,0 +1,42 @@
+package com.threegap.bitnagil.presentation.reportdetail.component.block
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.threegap.bitnagil.designsystem.BitnagilTheme
+
+@Composable
+fun ReportDetailLabeledContent(
+    modifier: Modifier = Modifier,
+    label: String,
+    content: String,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Text(
+            text = label,
+            style = BitnagilTheme.typography.body2SemiBold,
+            color = BitnagilTheme.colors.coolGray10,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = BitnagilTheme.colors.coolGray99, shape = RoundedCornerShape(12.dp))
+                .padding(vertical = 16.dp, horizontal = 20.dp),
+            text = content,
+            style = BitnagilTheme.typography.body2Medium,
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/ReportCategory.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/ReportCategory.kt
@@ -1,0 +1,31 @@
+package com.threegap.bitnagil.presentation.reportdetail.model
+import com.threegap.bitnagil.domain.report.model.ReportCategory as DomainReportCategory
+
+enum class ReportCategory(
+    val title: String,
+) {
+    TrafficFacilities(
+        title = "교통 시설",
+    ),
+    LightingFacilities(
+        title = "조명 시설",
+    ),
+    WaterFacilities(
+        title = "상하수도 시설",
+    ),
+    Amenities(
+        title = "편의 시설",
+    ),
+    ;
+
+    companion object {
+        fun fromDomain(domainReportCategory: com.threegap.bitnagil.domain.report.model.ReportCategory): ReportCategory {
+            return when (domainReportCategory) {
+                DomainReportCategory.TRANSPORTATION -> TrafficFacilities
+                DomainReportCategory.LIGHTING -> LightingFacilities
+                DomainReportCategory.WATERFACILITY -> WaterFacilities
+                DomainReportCategory.AMENITY -> Amenities
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/ReportProcess.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/ReportProcess.kt
@@ -1,0 +1,22 @@
+package com.threegap.bitnagil.presentation.reportdetail.model
+
+import com.threegap.bitnagil.domain.report.model.ReportStatus
+
+enum class ReportProcess(
+    val title: String,
+) {
+    Reported(title = "제보 완료"),
+    Progress(title = "처리 중"),
+    Complete(title = "처리 완료"),
+    ;
+
+    companion object {
+        fun fromDomain(status: ReportStatus): ReportProcess {
+            return when (status) {
+                ReportStatus.Pending -> Reported
+                ReportStatus.InProgress -> Progress
+                ReportStatus.Completed -> Complete
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/mvi/ReportDetailSideEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/mvi/ReportDetailSideEffect.kt
@@ -1,0 +1,3 @@
+package com.threegap.bitnagil.presentation.reportdetail.model.mvi
+
+interface ReportDetailSideEffect

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/mvi/ReportDetailState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/mvi/ReportDetailState.kt
@@ -1,0 +1,27 @@
+package com.threegap.bitnagil.presentation.reportdetail.model.mvi
+
+import com.threegap.bitnagil.presentation.reportdetail.model.ReportCategory
+import com.threegap.bitnagil.presentation.reportdetail.model.ReportProcess
+import java.time.LocalDate
+
+data class ReportDetailState(
+    val reportProcess: ReportProcess,
+    val reportTitle: String,
+    val reportContent: String,
+    val reportCategory: ReportCategory,
+    val imageUrls: List<String>,
+    val location: String,
+    val date: LocalDate,
+) {
+    companion object {
+        val Init = ReportDetailState(
+            reportProcess = ReportProcess.Reported,
+            reportTitle = "",
+            reportContent = "",
+            reportCategory = ReportCategory.TrafficFacilities,
+            imageUrls = emptyList(),
+            location = "",
+            date = LocalDate.now(),
+        )
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/navarg/ReportDetailScreenArg.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/navarg/ReportDetailScreenArg.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ReportDetailScreenArg(
-    val reportId: Int,
+    val reportId: String,
 )

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/navarg/ReportDetailScreenArg.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/model/navarg/ReportDetailScreenArg.kt
@@ -1,0 +1,8 @@
+package com.threegap.bitnagil.presentation.reportdetail.model.navarg
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReportDetailScreenArg(
+    val reportId: Int,
+)

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/util/LocalDateUtils.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/util/LocalDateUtils.kt
@@ -1,0 +1,10 @@
+package com.threegap.bitnagil.presentation.reportdetail.util
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+fun LocalDate.toPresentationFormatInReportDetail(): String {
+    val formatter = DateTimeFormatter.ofPattern("yy.MM.dd (E)", Locale.KOREAN)
+    return this.format(formatter)
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reporthistory/component/block/ReportHistoryItem.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reporthistory/component/block/ReportHistoryItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,6 +84,7 @@ fun ReportHistoryItem(
                 .size(74.dp)
                 .clip(shape = RoundedCornerShape(9.dp))
                 .background(color = BitnagilTheme.colors.black),
+            contentScale = ContentScale.Crop,
             contentDescription = null,
         )
     }


### PR DESCRIPTION
# [ PR Content ]
제보 상세조회 화면을 구현합니다.

## Related issue
- closed #154

## Screenshot 📸

https://github.com/user-attachments/assets/13c02aa8-9ec8-40a0-b8fd-e8d2b2a73675


## Work Description
- 제보 상세조회 화면 구현
- 제보 목록 화면에서 제보 이미지의 contentScale를 ContentScale.Crop
- 역지오코딩 호출시 road_address가 null일 때 파싱에러 발생하는 부분 수정

## To Reviewers 📢
- 개선점이나 궁금한 점 있으시면 코멘트 부탁드립니다!

## ETC
- 현 이슈에 대한 내용은 아니지만, #152 에서 수정한 내용을 반영했음에도 불구하고 여전히 세부 주소가 불러와지지 않아 Document의 roadAddress를 nullable한 타입으로 변경했습니다. 대현님이 테스트했을 때는 정상적으로 동작했었는지 확인차 여쭤봅니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제출된 신고의 상세 정보를 조회할 수 있는 신고 상세 화면 추가
  * 신고 상태, 제목, 내용, 카테고리, 이미지, 위치, 날짜 등 신고 정보 표시
  * 신고 상태를 시각적 배지로 표현
  * 신고 이미지 썸네일 프리뷰 기능 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->