### PR TITLE
[UI/#156] 제보 상세 화면 제보 이미지간 간격 추가

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/reportdetail/ReportDetailScreen.kt
@@ -85,7 +85,9 @@ private fun ReportDetailScreen(
 
             Spacer(modifier = Modifier.height(14.dp))
 
-            Row {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 state.imageUrls.forEach { imageUrl ->
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
@@ -143,6 +145,7 @@ private fun ReportDetailScreenPreview() {
                     "consectetur adipiscing elit," +
                     " sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
                     "Nisl tincidunt eget nullam non.",
+                imageUrls = listOf("", ""),
             ),
             onClickPreviousButton = {},
         )


### PR DESCRIPTION
# [ PR Content ]
제보 상세 화면에서 제보 이미지간 간격을 추가합니다.

## Related issue
- closed #156 

## Screenshot 📸

<img src="https://github.com/user-attachments/assets/6f5cb035-e985-43b3-86af-1c053158ca58" width="50%" />


## Work Description
- 제보 이미지간 간격 추가

## To Reviewers 📢
- 🖼️ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 리포트 상세 페이지에서 이미지 갤러리 내 이미지들 사이의 간격이 개선되어 더욱 명확한 시각적 구분이 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->