### PR TITLE
[UI/#179] 글자수 제한 추가 및 제보 최소 대기시간 수정

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -305,7 +304,6 @@ private fun ReportScreen(
                     value = uiState.reportContent,
                     onValueChange = onReportContentChange,
                     modifier = Modifier
-                        .height(88.dp)
                         .focusRequester(contentFocusRequester),
                     keyboardOptions = KeyboardOptions(
                         imeAction = ImeAction.Done,
@@ -322,6 +320,7 @@ private fun ReportScreen(
                             color = BitnagilTheme.colors.coolGray80,
                         )
                     },
+                    minLines = 3,
                 )
 
                 Text(

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
@@ -278,7 +278,6 @@ private fun ReportScreen(
                             color = BitnagilTheme.colors.coolGray80,
                         )
                     },
-                    maxLines = 2,
                     minLines = 2,
                 )
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportScreen.kt
@@ -265,7 +265,6 @@ private fun ReportScreen(
                 BitnagilTextField(
                     value = uiState.reportTitle,
                     onValueChange = onReportTitleChange,
-                    singleLine = true,
                     keyboardActions = KeyboardActions(
                         onDone = {
                             focusManager.clearFocus()
@@ -279,6 +278,16 @@ private fun ReportScreen(
                             color = BitnagilTheme.colors.coolGray80,
                         )
                     },
+                    maxLines = 2,
+                    minLines = 2,
+                )
+
+                Text(
+                    text = "${uiState.reportTitle.length} / ${ReportState.MAX_TITLE_LENGTH}",
+                    style = BitnagilTheme.typography.caption1Medium,
+                    color = BitnagilTheme.colors.coolGray80,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
 
@@ -309,7 +318,7 @@ private fun ReportScreen(
                     ),
                     placeholder = {
                         Text(
-                            text = "어떤 위험인지 간단히 설명해주세요.(100자 내외)",
+                            text = "어떤 위험인지 간단히 설명해주세요.(${ReportState.MAX_CONTENT_LENGTH}자 내외)",
                             style = BitnagilTheme.typography.body2Medium,
                             color = BitnagilTheme.colors.coolGray80,
                         )
@@ -317,7 +326,7 @@ private fun ReportScreen(
                 )
 
                 Text(
-                    text = "${uiState.reportContent.length} / 150",
+                    text = "${uiState.reportContent.length} / ${ReportState.MAX_CONTENT_LENGTH}",
                     style = BitnagilTheme.typography.caption1Medium,
                     color = BitnagilTheme.colors.coolGray80,
                     textAlign = TextAlign.End,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
@@ -36,12 +36,14 @@ class ReportViewModel @Inject constructor(
 
     fun updateReportTitle(title: String) {
         intent {
+            if (title.length > ReportState.MAX_TITLE_LENGTH) return@intent;
             reduce { state.copy(reportTitle = title) }
         }
     }
 
     fun updateReportContent(content: String) {
         intent {
+            if (content.length > ReportState.MAX_CONTENT_LENGTH) return@intent;
             reduce { state.copy(reportContent = content) }
         }
     }
@@ -129,7 +131,7 @@ class ReportViewModel @Inject constructor(
 
             coroutineScope {
                 val minDelayJob = async {
-                    delay(1000L)
+                    delay(timeMillis = ReportState.MIN_LOADING_TIME)
                 }
 
                 val processingJob = async {
@@ -174,7 +176,7 @@ class ReportViewModel @Inject constructor(
                             )
                         }
                     },
-                    onFailure = { error ->
+                    onFailure = { _ ->
                         reduce { state.copy(submitState = SubmitState.IDLE) }
                     },
                 )

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/ReportViewModel.kt
@@ -36,14 +36,14 @@ class ReportViewModel @Inject constructor(
 
     fun updateReportTitle(title: String) {
         intent {
-            if (title.length > ReportState.MAX_TITLE_LENGTH) return@intent;
+            if (title.length > ReportState.MAX_TITLE_LENGTH) return@intent
             reduce { state.copy(reportTitle = title) }
         }
     }
 
     fun updateReportContent(content: String) {
         intent {
-            if (content.length > ReportState.MAX_CONTENT_LENGTH) return@intent;
+            if (content.length > ReportState.MAX_CONTENT_LENGTH) return@intent
             reduce { state.copy(reportContent = content) }
         }
     }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/report/contract/ReportState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/report/contract/ReportState.kt
@@ -30,6 +30,10 @@ data class ReportState(
             currentLongitude != null
 
     companion object {
+        const val MAX_TITLE_LENGTH = 50
+        const val MAX_CONTENT_LENGTH = 150
+        const val MIN_LOADING_TIME = 1500L
+
         const val MAX_IMAGE_COUNT = 3
 
         val Init = ReportState(

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -166,7 +168,17 @@ private fun WriteRoutineScreen(
                 onClickRemove = null,
             )
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = "${state.routineName.length} / ${WriteRoutineState.MAX_ROUTINE_NAME_LENGTH}",
+                style = BitnagilTheme.typography.caption1Medium,
+                color = BitnagilTheme.colors.coolGray80,
+                textAlign = TextAlign.End,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/WriteRoutineViewModel.kt
@@ -158,6 +158,7 @@ class WriteRoutineViewModel @AssistedInject constructor(
     }
 
     fun setRoutineName(name: String) = intent {
+        if (name.length > WriteRoutineState.MAX_ROUTINE_NAME_LENGTH) return@intent
         reduce {
             state.copy(
                 routineName = name,

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/contract/WriteRoutineState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/writeroutine/contract/WriteRoutineState.kt
@@ -33,6 +33,8 @@ data class WriteRoutineState(
     val recommendedRoutineType: RecommendCategory?,
 ) : Parcelable {
     companion object {
+        const val MAX_ROUTINE_NAME_LENGTH = 20
+
         val INIT = WriteRoutineState(
             routineName = "",
             subRoutineNames = listOf("", "", ""),


### PR DESCRIPTION
# [ PR Content ]
- 루틴 작성/제보하기 화면에 추가된 글자 수 제약을 반영하고, 제보하기에서 로딩 뷰의 최소 표시 시간을 조정했습니다.

## Related issue
- closed #179 

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/0f045b8f-c93a-44c0-9f50-e7bf9003ce0c" width="360"/>

<img src="https://github.com/user-attachments/assets/1cbc0081-cea5-436b-9717-12e32263b904" width="360"/>

## Work Description
- 루틴 작성시 루틴 제목, 제보하기의 제보 제목의 글자수 제한을 추가
- 제보하기에서 제보시 로딩 UI가 표시되는 최소 시간 1초에서 1.5초로 조정
- 제보하기에서 일부 TextField의 고정 높이를 가변 높이로 변경

## To Reviewers 📢
- Figma상에는 제보 제목 TextField의 높이가 70 고정이라고 명시되었지만, zFlip 시리즈와 같이 가로가 짧은 일부 기기에서는 50자에 근접했을 때 3줄로 표시되어 일부 글자가 보이지 않는 문제가 있어 가변 높이로 변경하였습니다
- 궁금하거나 수정이 필요한 부분 있으면 코멘트 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 보고서 제목 입력 필드에 문자 수 표시 추가
  * 보고서 내용 입력 필드에 문자 수 표시 추가
  * 루틴 이름 입력 필드에 문자 수 표시 추가

* **버그 수정**
  * 입력 필드의 최대 문자 수 제한 적용으로 유효성 검사 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->