### PR TITLE
[Fix/#182] 홈 탭 진입 시 상태바 아이콘 색상이 변경되도록 합니다.

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainActivity.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainActivity.kt
@@ -46,9 +46,7 @@ class MainActivity : ComponentActivity() {
             }
 
             Box(modifier = Modifier.fillMaxSize()) {
-                MainScreen(
-                    navigator = mainNavigator,
-                )
+                MainScreen(navigator = mainNavigator)
 
                 BitnagilToastContainer(
                     state = globalToast,

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -56,7 +57,7 @@ fun HomeNavHost(
 
     val activity = LocalActivity.current
     val isHomeTab = navigator.isHomeRoute
-    SideEffect {
+    LaunchedEffect(isHomeTab) {
         activity?.setStatusBarContentColor(isLightContent = isHomeTab)
     }
 

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
@@ -3,6 +3,7 @@ package com.threegap.bitnagil.navigation.home
 import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +32,7 @@ import com.threegap.bitnagil.presentation.common.toast.GlobalBitnagilToast
 import com.threegap.bitnagil.presentation.home.HomeScreenContainer
 import com.threegap.bitnagil.presentation.mypage.MyPageScreenContainer
 import com.threegap.bitnagil.presentation.recommendroutine.RecommendRoutineScreenContainer
+import com.threegap.bitnagil.util.setStatusBarContentColor
 
 @Composable
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -50,6 +53,12 @@ fun HomeNavHost(
     var showFloatingOverlay by remember { mutableStateOf(false) }
 
     DoubleBackButtonPressedHandler()
+
+    val activity = LocalActivity.current
+    val isHomeTab = navigator.isHomeRoute
+    SideEffect {
+        activity?.setStatusBarContentColor(isLightContent = isHomeTab)
+    }
 
     Box(modifier = modifier.fillMaxSize()) {
         Scaffold(

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
@@ -11,16 +11,15 @@ class HomeNavigator(
 ) {
     val startDestination = HomeRoute.Home.route
 
-    @Composable
-    fun getCurrentRoute(): String? {
-        return navController.currentBackStackEntryAsState().value?.destination?.route
-    }
+    val currentRoute: String?
+        @Composable get() = navController.currentBackStackEntryAsState().value?.destination?.route
+
+    val isHomeRoute: Boolean
+        @Composable get() = currentRoute == HomeRoute.Home.route
 
     @Composable
-    fun shouldShowFloatingAction(): Boolean {
-        val currentRoute = getCurrentRoute()
-        return currentRoute == HomeRoute.Home.route || currentRoute == HomeRoute.RecommendRoutine.route
-    }
+    fun shouldShowFloatingAction(): Boolean =
+        currentRoute in setOf(HomeRoute.Home.route, HomeRoute.RecommendRoutine.route)
 }
 
 @Composable

--- a/app/src/main/java/com/threegap/bitnagil/util/UiExtensions.kt
+++ b/app/src/main/java/com/threegap/bitnagil/util/UiExtensions.kt
@@ -5,8 +5,11 @@ import androidx.core.view.WindowCompat
 
 fun Activity.setStatusBarContentColor(isLightContent: Boolean) {
     val window = this.window
-    val view = window.decorView
-    val wic = WindowCompat.getInsetsController(window, view)
+    val wic = WindowCompat.getInsetsController(window, window.decorView)
 
-    wic.isAppearanceLightStatusBars = !isLightContent
+    val targetAppearance = !isLightContent
+
+    if (wic.isAppearanceLightStatusBars != targetAppearance) {
+        wic.isAppearanceLightStatusBars = targetAppearance
+    }
 }

--- a/app/src/main/java/com/threegap/bitnagil/util/UiExtensions.kt
+++ b/app/src/main/java/com/threegap/bitnagil/util/UiExtensions.kt
@@ -1,0 +1,12 @@
+package com.threegap.bitnagil.util
+
+import android.app.Activity
+import androidx.core.view.WindowCompat
+
+fun Activity.setStatusBarContentColor(isLightContent: Boolean) {
+    val window = this.window
+    val view = window.decorView
+    val wic = WindowCompat.getInsetsController(window, view)
+
+    wic.isAppearanceLightStatusBars = !isLightContent
+}


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
홈 탭 여부에 따라 상태바 아이콘 색상이 동적으로 변경되도록 구현했습니다.

## Related issue
- closed #182 

## Screenshot 📸
https://github.com/user-attachments/assets/b4f4a435-c921-42ba-a87a-4b354198af05

## Work Description
- 상태바 색상 변경 로직 추가 `setStatusBarContentColor` -> [공식문서 link](https://developer.android.com/develop/ui/compose/system/insets-views-compose?hl=ko#system-bar-icons)

## To Reviewers 📢
- 궁금한 사항이 있다면 리뷰 남겨주십쇼~!
- 추가로 이번 작업간 `HomeNavigator` 클래스에 사용중이던 `getCurrentRoute()`가 동작보단 상태가 더 맞다고 생각하여 메소드에서 프로퍼티 방식으로 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 탭 여부에 따라 상태 표시줄의 콘텐츠 색상이 동적으로 변경됩니다(홈에서는 밝게, 다른 탭에서는 어둡게).

* **리팩토링**
  * 네비게이션 상태 관련 로직을 정리하여 탭 감지 및 플로팅 액션 표시 결정이 더 일관되게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->