### PR TITLE
[Refactor/#196] 네트워크 모듈 리팩토링 및 라이브러리 업데이트

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/di/core/NetworkModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/core/NetworkModule.kt
@@ -92,16 +92,41 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    @Kakao
-    fun provideKakaoOkHttpClient(
+    fun provideBaseOkHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
-        @Kakao kakaoAuthInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(kakaoAuthInterceptor)
         .addInterceptor(httpLoggingInterceptor)
         .connectTimeout(10L, TimeUnit.SECONDS)
         .writeTimeout(30L, TimeUnit.SECONDS)
         .readTimeout(30L, TimeUnit.SECONDS)
+        .build()
+
+    @Provides
+    @Singleton
+    @NoneAuth
+    fun provideNoneAuthOkHttpClient(baseClient: OkHttpClient): OkHttpClient =
+        baseClient.newBuilder().build()
+
+    @Provides
+    @Singleton
+    @Auth
+    fun provideAuthOkHttpClient(
+        baseClient: OkHttpClient,
+        @Auth authInterceptor: Interceptor,
+        tokenAuthenticator: TokenAuthenticator,
+    ): OkHttpClient = baseClient.newBuilder()
+        .addInterceptor(authInterceptor)
+        .authenticator(tokenAuthenticator)
+        .build()
+
+    @Provides
+    @Singleton
+    @Kakao
+    fun provideKakaoOkHttpClient(
+        baseClient: OkHttpClient,
+        @Kakao kakaoAuthInterceptor: Interceptor,
+    ): OkHttpClient = baseClient.newBuilder()
+        .addInterceptor(kakaoAuthInterceptor)
         .build()
 
     @Provides
@@ -140,34 +165,6 @@ object NetworkModule {
     @Auth
     fun provideAuthInterceptor(tokenProvider: TokenProvider): Interceptor =
         AuthInterceptor(tokenProvider)
-
-    @Provides
-    @Singleton
-    @Auth
-    fun provideAuthOkHttpClient(
-        httpLoggingInterceptor: HttpLoggingInterceptor,
-        @Auth authInterceptor: Interceptor,
-        tokenAuthenticator: TokenAuthenticator,
-    ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(authInterceptor)
-        .addInterceptor(httpLoggingInterceptor)
-        .authenticator(tokenAuthenticator)
-        .connectTimeout(10L, TimeUnit.SECONDS)
-        .writeTimeout(30L, TimeUnit.SECONDS)
-        .readTimeout(30L, TimeUnit.SECONDS)
-        .build()
-
-    @Provides
-    @Singleton
-    @NoneAuth
-    fun provideNoneAuthOkHttpClient(
-        httpLoggingInterceptor: HttpLoggingInterceptor,
-    ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(httpLoggingInterceptor)
-        .connectTimeout(10L, TimeUnit.SECONDS)
-        .writeTimeout(30L, TimeUnit.SECONDS)
-        .readTimeout(30L, TimeUnit.SECONDS)
-        .build()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
@@ -20,6 +20,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -28,61 +29,49 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun provideAuthService(@Auth retrofit: Retrofit): AuthService =
-        retrofit.create(AuthService::class.java)
+    fun provideAuthService(@Auth retrofit: Retrofit): AuthService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideLoginService(@NoneAuth retrofit: Retrofit): LoginService =
-        retrofit.create(LoginService::class.java)
+    fun provideLoginService(@NoneAuth retrofit: Retrofit): LoginService = retrofit.create()
 
     @Provides
     @Singleton
-    fun providerOnBoardingService(@Auth retrofit: Retrofit): OnBoardingService =
-        retrofit.create(OnBoardingService::class.java)
+    fun providerOnBoardingService(@Auth retrofit: Retrofit): OnBoardingService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideRoutineService(@Auth retrofit: Retrofit): RoutineService =
-        retrofit.create(RoutineService::class.java)
+    fun provideRoutineService(@Auth retrofit: Retrofit): RoutineService = retrofit.create()
 
     @Provides
     @Singleton
-    fun providerEmotionService(@Auth retrofit: Retrofit): EmotionService =
-        retrofit.create(EmotionService::class.java)
+    fun providerEmotionService(@Auth retrofit: Retrofit): EmotionService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideReissueService(@NoneAuth retrofit: Retrofit): ReissueService =
-        retrofit.create(ReissueService::class.java)
+    fun provideReissueService(@NoneAuth retrofit: Retrofit): ReissueService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideUserService(@Auth retrofit: Retrofit): UserService =
-        retrofit.create(UserService::class.java)
+    fun provideUserService(@Auth retrofit: Retrofit): UserService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideRecommendRoutineService(@Auth retrofit: Retrofit): RecommendRoutineService =
-        retrofit.create(RecommendRoutineService::class.java)
+    fun provideRecommendRoutineService(@Auth retrofit: Retrofit): RecommendRoutineService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideVersionService(@NoneAuth retrofit: Retrofit): VersionService =
-        retrofit.create(VersionService::class.java)
+    fun provideVersionService(@NoneAuth retrofit: Retrofit): VersionService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideAddressService(@Kakao retrofit: Retrofit): AddressService =
-        retrofit.create(AddressService::class.java)
+    fun provideAddressService(@Kakao retrofit: Retrofit): AddressService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideFileService(@Auth retrofit: Retrofit): FileService =
-        retrofit.create(FileService::class.java)
+    fun provideFileService(@Auth retrofit: Retrofit): FileService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideReportService(@Auth retrofit: Retrofit): ReportService =
-        retrofit.create(ReportService::class.java)
+    fun provideReportService(@Auth retrofit: Retrofit): ReportService = retrofit.create()
 }

--- a/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/data/ServiceModule.kt
@@ -2,6 +2,7 @@ package com.threegap.bitnagil.di.data
 
 import com.threegap.bitnagil.data.address.service.AddressService
 import com.threegap.bitnagil.data.auth.service.AuthService
+import com.threegap.bitnagil.data.auth.service.LoginService
 import com.threegap.bitnagil.data.emotion.service.EmotionService
 import com.threegap.bitnagil.data.file.service.FileService
 import com.threegap.bitnagil.data.onboarding.service.OnBoardingService
@@ -29,6 +30,11 @@ object ServiceModule {
     @Singleton
     fun provideAuthService(@Auth retrofit: Retrofit): AuthService =
         retrofit.create(AuthService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLoginService(@NoneAuth retrofit: Retrofit): LoginService =
+        retrofit.create(LoginService::class.java)
 
     @Provides
     @Singleton

--- a/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/extension/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/threegap/bitnagil/convention/extension/KotlinAndroid.kt
@@ -44,6 +44,7 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, 
             resources {
                 excludes.add("META-INF/AL2.0")
                 excludes.add("META-INF/LGPL2.1")
+                excludes.add("META-INF/versions/9/OSGI-INF/MANIFEST.MF")
             }
         }
 

--- a/core/network/src/main/java/com/threegap/bitnagil/network/auth/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/threegap/bitnagil/network/auth/AuthInterceptor.kt
@@ -3,7 +3,6 @@ package com.threegap.bitnagil.network.auth
 import com.threegap.bitnagil.network.token.TokenProvider
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 
 class AuthInterceptor(
@@ -11,16 +10,9 @@ class AuthInterceptor(
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val noToken = originalRequest.header(HEADER_NO_SERVICE_TOKEN)
-
-        if (noToken == "true") {
-            return chain.proceed(removeNoTokenHeader(originalRequest))
-        }
 
         val token = runBlocking { tokenProvider.getAccessToken() }
-        if (token.isNullOrBlank()) {
-            return chain.proceed(originalRequest)
-        }
+        if (token.isNullOrBlank()) return chain.proceed(originalRequest)
 
         val newRequest = originalRequest.newBuilder()
             .addHeader(HEADER_AUTHORIZATION, "$TOKEN_PREFIX $token")
@@ -29,13 +21,7 @@ class AuthInterceptor(
         return chain.proceed(newRequest)
     }
 
-    private fun removeNoTokenHeader(request: Request): Request =
-        request.newBuilder()
-            .removeHeader(HEADER_NO_SERVICE_TOKEN)
-            .build()
-
     companion object {
-        private const val HEADER_NO_SERVICE_TOKEN = "No-Service-Token"
         private const val HEADER_AUTHORIZATION = "Authorization"
         private const val TOKEN_PREFIX = "Bearer"
     }

--- a/core/network/src/main/java/com/threegap/bitnagil/network/auth/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/threegap/bitnagil/network/auth/TokenAuthenticator.kt
@@ -19,7 +19,6 @@ class TokenAuthenticator(
     private val authMutex = Mutex()
 
     override fun authenticate(route: Route?, response: Response): Request? {
-        if (response.request.header(AUTO_LOGIN_HEADER) != null) return null
         if (!shouldRetry(response)) return null
 
         val currentToken = runBlocking { tokenProvider.getAccessToken() }
@@ -83,7 +82,6 @@ class TokenAuthenticator(
     private fun buildRequestWithToken(originalRequest: Request, token: String): Request {
         return originalRequest.newBuilder()
             .header(AUTHORIZATION, "$TOKEN_PREFIX $token")
-            .removeHeader(AUTO_LOGIN_HEADER)
             .build()
     }
 
@@ -98,6 +96,5 @@ class TokenAuthenticator(
         private const val AUTHORIZATION = "Authorization"
         private const val TOKEN_PREFIX = "Bearer"
         private const val SUCCESS_CODE = "CO000"
-        private const val AUTO_LOGIN_HEADER = "Auto-Login"
     }
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
@@ -6,16 +6,18 @@ import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequest
 import com.threegap.bitnagil.data.auth.model.request.WithdrawalReasonRequest
 import com.threegap.bitnagil.data.auth.model.response.LoginResponse
 import com.threegap.bitnagil.data.auth.service.AuthService
+import com.threegap.bitnagil.data.auth.service.LoginService
 import com.threegap.bitnagil.data.common.safeApiCall
 import com.threegap.bitnagil.data.common.safeUnitApiCall
 import javax.inject.Inject
 
 class AuthRemoteDataSourceImpl @Inject constructor(
     private val authService: AuthService,
+    private val loginService: LoginService,
 ) : AuthRemoteDataSource {
     override suspend fun login(socialAccessToken: String, loginRequest: LoginRequest): Result<LoginResponse> =
         safeApiCall {
-            authService.postLogin(socialAccessToken, loginRequest)
+            loginService.postLogin(socialAccessToken, loginRequest)
         }
 
     override suspend fun submitAgreement(termsAgreementRequest: TermsAgreementRequest): Result<Unit> =
@@ -35,6 +37,6 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun reissueToken(refreshToken: String): Result<LoginResponse> =
         safeApiCall {
-            authService.postReissueToken(refreshToken)
+            loginService.postReissueToken(refreshToken)
         }
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/service/AuthService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/service/AuthService.kt
@@ -1,23 +1,12 @@
 package com.threegap.bitnagil.data.auth.service
 
-import com.threegap.bitnagil.data.auth.model.request.LoginRequest
 import com.threegap.bitnagil.data.auth.model.request.TermsAgreementRequest
 import com.threegap.bitnagil.data.auth.model.request.WithdrawalReasonRequest
-import com.threegap.bitnagil.data.auth.model.response.LoginResponse
 import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.Body
-import retrofit2.http.Header
-import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface AuthService {
-    @POST("/api/v1/auth/login")
-    @Headers("No-Service-Token: true")
-    suspend fun postLogin(
-        @Header("SocialAccessToken") socialAccessToken: String,
-        @Body loginRequest: LoginRequest,
-    ): BaseResponse<LoginResponse>
-
     @POST("/api/v1/auth/agreements")
     suspend fun submitAgreement(
         @Body termsAgreementRequest: TermsAgreementRequest,
@@ -28,10 +17,4 @@ interface AuthService {
 
     @POST("/api/v1/auth/logout")
     suspend fun postLogout(): BaseResponse<Unit>
-
-    @POST("/api/v1/auth/token/reissue")
-    @Headers("No-Service-Token: true", "Auto-Login: true")
-    suspend fun postReissueToken(
-        @Header("Refresh-Token") refreshToken: String,
-    ): BaseResponse<LoginResponse>
 }

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/service/LoginService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/service/LoginService.kt
@@ -1,0 +1,23 @@
+package com.threegap.bitnagil.data.auth.service
+
+import com.threegap.bitnagil.data.auth.model.request.LoginRequest
+import com.threegap.bitnagil.data.auth.model.response.LoginResponse
+import com.threegap.bitnagil.network.model.BaseResponse
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+interface LoginService {
+    @POST("/api/v1/auth/login")
+    suspend fun postLogin(
+        @Header("SocialAccessToken") socialAccessToken: String,
+        @Body loginRequest: LoginRequest,
+    ): BaseResponse<LoginResponse>
+
+    @POST("/api/v1/auth/token/reissue")
+    @Headers("Auto-Login: true")
+    suspend fun postReissueToken(
+        @Header("Refresh-Token") refreshToken: String,
+    ): BaseResponse<LoginResponse>
+}

--- a/data/src/main/java/com/threegap/bitnagil/data/auth/service/LoginService.kt
+++ b/data/src/main/java/com/threegap/bitnagil/data/auth/service/LoginService.kt
@@ -5,7 +5,6 @@ import com.threegap.bitnagil.data.auth.model.response.LoginResponse
 import com.threegap.bitnagil.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.Header
-import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface LoginService {
@@ -16,7 +15,6 @@ interface LoginService {
     ): BaseResponse<LoginResponse>
 
     @POST("/api/v1/auth/token/reissue")
-    @Headers("Auto-Login: true")
     suspend fun postReissueToken(
         @Header("Refresh-Token") refreshToken: String,
     ): BaseResponse<LoginResponse>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,8 +40,8 @@ composeBom = "2025.06.00"
 composeNavigation = "2.9.0"
 
 # Network
-okhttp = "4.11.0"
-retrofit = "2.11.0"
+okhttp = "5.3.2"
+retrofit = "3.0.0"
 
 # Test
 junit = "4.13.2"


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->

## Related issue
- closed #196

## Work Description
- NetworkModule & ServiceModule 리팩토링: 
   - NetworkModule.kt: 중복되던 OkHttpClient 설정 로직을 BaseOkHttpClient로 추출
- 인증 로직 고도화:
   - AuthInterceptor.kt 및 TokenAuthenticator.kt에서 더 이상 사용하지 않는 Auto-Login 관련 헤더 로직을 제거하였습니다.
   - 인증이 필요 없는 로그인 관련 API를 별도의 LoginService로 분리하여 계층 구조를 명확히 하였습니다.
- 라이브러리 버전 업데이트:
   - libs.versions.toml: OkHttp를 4.11.0에서 5.3.2로, Retrofit을 2.11.0에서 3.0.0으로 업데이트

## To Reviewers 📢
- 기존 방식은 `@Auth`, `@NoneAuth`, `@Kakao` 등 각각의 목적에 맞는 클라이언트를 생성할 때 매번 `OkHttpClient.Builder().build()`를 독립적으로 호출합니다. 이 경우 클라이언트가 생성될 때마다 내부적으로 별도의 커넥션 풀과 스레드 풀이 각각 새로 만들어지는 문제가 있습니다. 이를 `baseClient.newBuilder()`를 활용해 단일 Base 클라이언트를 하나만 생성하고 이를 기반으로 생성되도록 수정했습니다.
개선 효과: 앱 전체의 네트워크 요청이 단 1개의 스레드풀과 커넥션풀을 공유하게 됩니다!
<img width="1000" height="250" src="https://github.com/user-attachments/assets/0b849667-7b26-4cf8-9b2e-d31089142147" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 및 토큰 재발급 기능을 위한 통합 서비스 추가
  
* **개선사항**
  * 네트워크 인증 처리 로직 간소화
  * OkHttp 5.3.2, Retrofit 3.0.0으로 업데이트하여 네트워크 성능 및 안정성 향상
  
* **리팩토링**
  * 의존성 주입 구조 최적화로 서비스 모듈 재구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->