### PR TITLE
[Fix/#203] 홈 화면 Collapsible Header 플링 시 하단 검정 배경 노출문제 해결

### DIFF
--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/HomeScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -102,7 +104,11 @@ private fun HomeScreen(
         StickyHeader(
             modifier = Modifier
                 .padding(top = 14.dp)
-                .height(collapsibleHeaderState.stickyHeaderHeightDp),
+                .height(collapsibleHeaderState.initialStickyHeaderHeightDp)
+                .onGloballyPositioned { coordinates ->
+                    collapsibleHeaderState.stickyHeaderActualBottomPx =
+                        coordinates.boundsInParent().bottom
+                },
             onHelpClick = onHelpClick,
         )
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
@@ -27,8 +27,9 @@ internal class CollapsibleHeaderState(
     val expandedHeaderHeightDp: Dp,
 ) {
     private val expandedHeaderHeightPx: Float = with(density) { expandedHeaderHeightDp.toPx() }
+    private val initialStickyHeaderHeightPx: Float = with(density) { initialStickyHeaderHeightDp.toPx() }
 
-    var stickyHeaderActualBottomPx by mutableFloatStateOf(0f)
+    var stickyHeaderActualBottomPx by mutableFloatStateOf(initialStickyHeaderHeightPx)
         internal set
 
     val collapsedContentOffsetDp: Dp

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
@@ -56,8 +56,7 @@ internal class CollapsibleHeaderState(
             val target = when {
                 available.y < -50f -> 0f
                 available.y > 50f -> expandedHeaderHeightPx
-                else -> if (currentHeightPx < expandedHeaderHeightPx / 2) 0f
-                else expandedHeaderHeightPx
+                else -> if (currentHeightPx < expandedHeaderHeightPx / 2) 0f else expandedHeaderHeightPx
             }
 
             snapTo(targetHeight = target, velocity = available.y)
@@ -87,7 +86,6 @@ internal class CollapsibleHeaderState(
                 stiffness = Spring.StiffnessMediumLow,
             ),
         ) { value, _ -> currentHeightPx = value.coerceIn(0f, expandedHeaderHeightPx) }
-
     }
 }
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/model/CollapsibleHeaderState.kt
@@ -23,20 +23,22 @@ import androidx.compose.ui.unit.dp
 @Stable
 internal class CollapsibleHeaderState(
     private val density: Density,
-    val stickyHeaderHeightDp: Dp,
+    val initialStickyHeaderHeightDp: Dp,
     val expandedHeaderHeightDp: Dp,
 ) {
-    private val stickyHeaderHeightPx: Float = with(density) { stickyHeaderHeightDp.toPx() }
-
     private val expandedHeaderHeightPx: Float = with(density) { expandedHeaderHeightDp.toPx() }
 
-    val collapsedContentOffsetDp: Dp = with(density) { stickyHeaderHeightPx.toDp() + 18.dp }
+    var stickyHeaderActualBottomPx by mutableFloatStateOf(0f)
+        internal set
+
+    val collapsedContentOffsetDp: Dp
+        get() = with(density) { stickyHeaderActualBottomPx.toDp() }
 
     var currentHeightPx by mutableFloatStateOf(expandedHeaderHeightPx)
         private set
 
     val expansionProgress: Float
-        get() = if (expandedHeaderHeightPx > 0f) (currentHeightPx / expandedHeaderHeightPx).coerceIn(0f, 1f) else 1f
+        get() = (currentHeightPx / expandedHeaderHeightPx).coerceIn(0f, 1f)
 
     val nestedScrollConnection = object : NestedScrollConnection {
         override fun onPreScroll(available: Offset, source: NestedScrollSource) =
@@ -46,33 +48,23 @@ internal class CollapsibleHeaderState(
             if (available.y > 0) consumeDelta(available.y) else Offset.Zero
 
         override suspend fun onPreFling(available: Velocity): Velocity {
-            if (currentHeightPx <= 0f || currentHeightPx >= expandedHeaderHeightPx) return Velocity.Zero
+            val isFullyCollapsed = currentHeightPx < 1f
+            val isFullyExpanded = currentHeightPx > expandedHeaderHeightPx - 1f
 
-            val collapse = 0f
-            val expand = expandedHeaderHeightPx
+            if (isFullyCollapsed || isFullyExpanded) return Velocity.Zero
 
             val target = when {
-                available.y < -50f -> collapse
-                available.y > 50f -> expand
-                else -> if (currentHeightPx - collapse < expand - currentHeightPx) collapse else expand
+                available.y < -50f -> 0f
+                available.y > 50f -> expandedHeaderHeightPx
+                else -> if (currentHeightPx < expandedHeaderHeightPx / 2) 0f
+                else expandedHeaderHeightPx
             }
 
             snapTo(targetHeight = target, velocity = available.y)
-
-            return Velocity(0f, available.y)
+            return Velocity.Zero
         }
 
         override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-            if (available.y > 0 && currentHeightPx < expandedHeaderHeightPx) {
-                snapTo(targetHeight = expandedHeaderHeightPx, velocity = available.y)
-                return Velocity(0f, available.y)
-            }
-
-            if (available.y < 0 && currentHeightPx > 0f) {
-                snapTo(targetHeight = 0f, velocity = available.y)
-                return Velocity(0f, available.y)
-            }
-
             return Velocity.Zero
         }
     }
@@ -94,9 +86,8 @@ internal class CollapsibleHeaderState(
                 dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessMediumLow,
             ),
-        ) { value, _ ->
-            currentHeightPx = value
-        }
+        ) { value, _ -> currentHeightPx = value.coerceIn(0f, expandedHeaderHeightPx) }
+
     }
 }
 
@@ -104,17 +95,17 @@ internal class CollapsibleHeaderState(
 internal fun rememberCollapsibleHeaderState(
     density: Density = LocalDensity.current,
     windowInfo: WindowInfo = LocalWindowInfo.current,
-    stickyHeaderHeight: Dp = 48.dp,
+    initialStickyHeaderHeightDp: Dp = 48.dp,
     minExpandedHeaderHeight: Dp = 146.dp,
 ): CollapsibleHeaderState {
     val containerSize = windowInfo.containerSize
-    return remember(density, containerSize, minExpandedHeaderHeight, stickyHeaderHeight) {
+    return remember(density, containerSize, minExpandedHeaderHeight, initialStickyHeaderHeightDp) {
         val screenHeightDp = with(density) { containerSize.height.toDp() }
         val expandedHeaderHeightDp = (screenHeightDp * 0.18f).coerceAtLeast(minExpandedHeaderHeight)
 
         CollapsibleHeaderState(
             density = density,
-            stickyHeaderHeightDp = stickyHeaderHeight,
+            initialStickyHeaderHeightDp = initialStickyHeaderHeightDp,
             expandedHeaderHeightDp = expandedHeaderHeightDp,
         )
     }


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
홈 화면 Collapsible Header 플링 시 하단 검정 배경 노출되던 문제를 수정했습니다.

## Related issue
- closed #203 

## Screenshot 📸
| 수정 전 | 수정 후 |
|---|---|
| <video src="https://github.com/user-attachments/assets/056aece3-e386-4393-a460-cf6dcfdd10f1"> | <video src="https://github.com/user-attachments/assets/ab569566-81e3-4b6a-b679-c1daeabd2fd7"> |

## Work Description
- NestedScrollConnection 내 snap 애니메이션 로직에 오버슈트로 인한 범위 이탈 방지 코드 추가
- onGloballyPositioned를 사용하여 StickyHeader의 실제 하단 위치를 기반으로 content offset을 계산하도록 수정

## To Reviewers 📢
- 잔 버그이긴 했는데 개인적으로 신경이 쓰여서 원인을 파악하고 수정해봤습니다.
- 원인: 
  - 플링 시 snapTo는 spring 애니메이션으로 currentHeightPx를 0f로 수렴시키는데, 초기 velocity(플랑 속도)가 클 경우 목표값을 순간적으로 지나치는 오버슈트가 발생합니다. 때문에 오버슈트로 currentHeightPx가 음수가 되면 translationY도 음수가 되어 Column이 위로 이동합니다.
  - 요기서 graphicsLayer의 translationY는 시각적 이동만 담당하고 레이아웃 공간은 바꾸지 않으므로, Column이 위로 올라간 만큼 하단에 빈 공간이 생기는 것이 원인이었습니다..
- 해결방법:
  - 원인 파악과정과 달리 해결방법은 단순했는데,, animate 콜백에서도 coerceIn을 적용하여 spring 오버슈트로 인한 범위 이탈을 방지할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 런타임에서 스티키 헤더의 실제 하단 위치를 측정해 스크롤/붕괴 동작의 위치 계산 정확도가 향상되었습니다.
  * 펼침/접힘 애니메이션과 플링 처리의 경계 및 스냅 동작을 개선해 불안정한 튕김이나 과도한 이동을 줄였습니다.

* **리팩터**
  * 초기 헤더 높이와 런타임 측정값을 분리해 레이아웃 및 오프셋 계산을 더 명확하고 안정적으로 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->