### PR TITLE
[Refactor/#205] 네비게이션 로직 수정

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeBottomNavigationBar.kt
@@ -20,19 +20,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.compose.currentBackStackEntryAsState
 import com.threegap.bitnagil.designsystem.BitnagilTheme
 import com.threegap.bitnagil.designsystem.component.atom.BitnagilIcon
 
 @Composable
 fun HomeBottomNavigationBar(
-    navController: NavController,
+    selectedTab: HomeRoute,
+    onTabSelected: (HomeRoute) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
-
-    Column {
+    Column(modifier = modifier) {
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),
             thickness = 1.dp,
@@ -47,19 +44,13 @@ fun HomeBottomNavigationBar(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            HomeRoute.entries.map { homeRoute ->
+            homeTabList.forEach { homeTab ->
                 HomeBottomNavigationItem(
                     modifier = Modifier.weight(1f),
-                    icon = homeRoute.icon,
-                    title = homeRoute.title,
-                    onClick = {
-                        if (currentRoute != homeRoute.route) {
-                            navController.navigate(homeRoute.route) {
-                                popUpTo(0) { inclusive = true }
-                            }
-                        }
-                    },
-                    selected = currentRoute == homeRoute.route,
+                    icon = homeTab.icon,
+                    title = homeTab.title,
+                    selected = selectedTab == homeTab.route,
+                    onClick = { onTabSelected(homeTab.route) },
                 )
             }
         }
@@ -71,8 +62,8 @@ private fun HomeBottomNavigationItem(
     modifier: Modifier = Modifier,
     icon: Int,
     title: String,
-    onClick: () -> Unit,
     selected: Boolean,
+    onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -111,9 +102,8 @@ private fun HomeBottomNavigationItem(
 @Composable
 @Preview
 private fun HomeBottomNavigationBarPreview() {
-    val navigator = rememberHomeNavigator()
-
     HomeBottomNavigationBar(
-        navController = navigator.navController,
+        selectedTab = HomeRoute.Home,
+        onTabSelected = {},
     )
 }

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
@@ -60,11 +60,16 @@ fun HomeNavHost(
         activity?.setStatusBarContentColor(isLightContent = isHomeTab)
     }
 
+    val selectedBottomTab = navigator.currentHomeRoute ?: navigator.startDestination
+
     Box(modifier = modifier.fillMaxSize()) {
         Scaffold(
             modifier = Modifier.fillMaxSize(),
             bottomBar = {
-                HomeBottomNavigationBar(navController = navigator.navController)
+                HomeBottomNavigationBar(
+                    selectedTab = selectedBottomTab,
+                    onTabSelected = navigator::navigateTo,
+                )
             },
             contentWindowInsets = WindowInsets(0.dp, 0.dp, 0.dp, 0.dp),
             content = { innerPadding ->
@@ -73,7 +78,7 @@ fun HomeNavHost(
                     startDestination = navigator.startDestination,
                     modifier = modifier.padding(innerPadding),
                 ) {
-                    composable(HomeRoute.Home.route) {
+                    composable<HomeRoute.Home> {
                         HomeScreenContainer(
                             navigateToGuide = navigateToGuide,
                             navigateToRegisterRoutine = {
@@ -86,14 +91,14 @@ fun HomeNavHost(
                         )
                     }
 
-                    composable(HomeRoute.RecommendRoutine.route) {
+                    composable<HomeRoute.RecommendRoutine> {
                         RecommendRoutineScreenContainer(
                             navigateToEmotion = navigateToEmotion,
                             navigateToRegisterRoutine = navigateToRegisterRoutine,
                         )
                     }
 
-                    composable(HomeRoute.MyPage.route) {
+                    composable<HomeRoute.MyPage> {
                         MyPageScreenContainer(
                             navigateToSetting = navigateToSetting,
                             navigateToOnBoarding = navigateToOnBoarding,

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
@@ -27,8 +27,7 @@ class HomeNavigator(
         @Composable get() = currentHomeRoute == HomeRoute.Home
 
     @Composable
-    fun shouldShowFloatingAction(): Boolean =
-        currentHomeRoute == HomeRoute.Home || currentHomeRoute == HomeRoute.RecommendRoutine
+    fun shouldShowFloatingAction(): Boolean = currentHomeRoute?.showFloatingButton == true
 
     fun navigateTo(route: HomeRoute) {
         navController.navigate(route) {

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
@@ -2,6 +2,7 @@ package com.threegap.bitnagil.navigation.home
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -9,17 +10,31 @@ import androidx.navigation.compose.rememberNavController
 class HomeNavigator(
     val navController: NavHostController,
 ) {
-    val startDestination = HomeRoute.Home.route
+    val startDestination: HomeRoute = HomeRoute.Home
 
-    val currentRoute: String?
-        @Composable get() = navController.currentBackStackEntryAsState().value?.destination?.route
+    val currentHomeRoute: HomeRoute?
+        @Composable get() {
+            val destination = navController.currentBackStackEntryAsState().value?.destination
+            return when {
+                destination?.hasRoute(HomeRoute.Home::class) == true -> HomeRoute.Home
+                destination?.hasRoute(HomeRoute.RecommendRoutine::class) == true -> HomeRoute.RecommendRoutine
+                destination?.hasRoute(HomeRoute.MyPage::class) == true -> HomeRoute.MyPage
+                else -> null
+            }
+        }
 
     val isHomeRoute: Boolean
-        @Composable get() = currentRoute == HomeRoute.Home.route
+        @Composable get() = currentHomeRoute == HomeRoute.Home
 
     @Composable
     fun shouldShowFloatingAction(): Boolean =
-        currentRoute in setOf(HomeRoute.Home.route, HomeRoute.RecommendRoutine.route)
+        currentHomeRoute == HomeRoute.Home || currentHomeRoute == HomeRoute.RecommendRoutine
+
+    fun navigateTo(route: HomeRoute) {
+        navController.navigate(route) {
+            popUpTo(0) { inclusive = true }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeRoute.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeRoute.kt
@@ -1,28 +1,28 @@
 package com.threegap.bitnagil.navigation.home
 
 import com.threegap.bitnagil.R
+import kotlinx.serialization.Serializable
 
-enum class HomeRoute(
-    val route: String,
+@Serializable
+sealed interface HomeRoute {
+    @Serializable
+    data object Home : HomeRoute
+
+    @Serializable
+    data object RecommendRoutine : HomeRoute
+
+    @Serializable
+    data object MyPage : HomeRoute
+}
+
+data class HomeTab(
+    val route: HomeRoute,
     val title: String,
     val icon: Int,
-) {
-    Home(
-        route = "home/home",
-        title = "홈",
-        icon = R.drawable.ic_home,
-    ),
+)
 
-    RecommendRoutine(
-        route = "home/recommend_routine",
-        title = "추천 루틴",
-        icon = R.drawable.ic_routine_recommend,
-    ),
-
-    MyPage(
-        route = "home/my_page",
-        title = "마이페이지",
-        icon = R.drawable.ic_profile,
-    ),
-    ;
-}
+val homeTabList = listOf(
+    HomeTab(HomeRoute.Home, "홈", R.drawable.ic_home),
+    HomeTab(HomeRoute.RecommendRoutine, "추천 루틴", R.drawable.ic_routine_recommend),
+    HomeTab(HomeRoute.MyPage, "마이페이지", R.drawable.ic_profile),
+)

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeRoute.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeRoute.kt
@@ -5,14 +5,22 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed interface HomeRoute {
-    @Serializable
-    data object Home : HomeRoute
+    val showFloatingButton: Boolean
 
     @Serializable
-    data object RecommendRoutine : HomeRoute
+    data object Home : HomeRoute {
+        override val showFloatingButton: Boolean = true
+    }
 
     @Serializable
-    data object MyPage : HomeRoute
+    data object RecommendRoutine : HomeRoute {
+        override val showFloatingButton: Boolean = true
+    }
+
+    @Serializable
+    data object MyPage : HomeRoute {
+        override val showFloatingButton: Boolean = false
+    }
 }
 
 data class HomeTab(


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
homeRoute 부분에 사용중이던 String 방식을 제거하고 type-safe 방식으로 통일했습니다.

## Related issue
- closed #205 

## Screenshot 📸
- N/A

## Work Description
- HomeRoute를 Enum에서 @Serializable Sealed Interface로 변경
- HomeNavigator 내 경로 확인 및 이동 로직을 Type-safe 방식으로 수정
- HomeBottomNavigationBar에서 NavController 의존성 제거 및 상태/이벤트 기반으로 변경

## To Reviewers 📢
- 간단한 작업이라 없을거 같긴한데 궁금한게 있다면 리뷰 남겨주세요~
- nav3로 마이그레이션 할때 좀 더 편해질거 같네용..,
- 추가로 작업하면서 발견한 이슈긴 한데 홈화면에서 바텀탭 이동을 기준으로 status bar icon 색을 동적으로 변경하고 있는데 (홈 -> 감정등록, 루틴 등록, 제보 등)이 경우에는 바텀탭이 아닌 외부 화면(MainNavHost)로 이동한것이라 색상이 변하지 않는 문제를 발견했습니다.. 해당 문제를 해결하려면 mian, home 으로 나뉜 NavHost를 하나의 NavHost로 통합하는 방법 or 각 화면에서 status bar icon색을 설정하는 방법이 있는데 둘중 고민이네용 (일단 엄청 후순위로 당분간은 하지 않은거 같긴합니다 ㅎ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 하단 탭 제어를 상태/이벤트 기반으로 전환해 탭 선택이 더 예측 가능하고 일관되게 동작합니다.
  * 하단 탭 목록을 중앙에서 관리하여 아이콘·타이틀 표시가 통일되었습니다.
* **New Features**
  * 하단 바 프리뷰가 간소화되어 개발 중 화면 미리보기가 더 간편해졌습니다.
* **버그 수정**
  * 탭 전환 시 백스택 처리와 플로팅 버튼 표시가 보다 정확하게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->