### PR TITLE
[Feature/#209] Coil3 커스텀 ImageLoader 설정 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,4 +100,5 @@ dependencies {
     implementation(libs.bundles.retrofit)
     implementation(platform(libs.okhttp.bom))
     implementation(libs.bundles.okhttp)
+    implementation(libs.bundles.coil)
 }

--- a/app/src/main/java/com/threegap/bitnagil/BitnagilApplication.kt
+++ b/app/src/main/java/com/threegap/bitnagil/BitnagilApplication.kt
@@ -7,7 +7,6 @@ import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
-import coil3.request.CachePolicy
 import coil3.request.crossfade
 import coil3.util.DebugLogger
 import com.kakao.sdk.common.KakaoSdk
@@ -42,8 +41,6 @@ class BitnagilApplication : Application(), SingletonImageLoader.Factory {
                     .maxSizeBytes(50L * 1024 * 1024)
                     .build()
             }
-            .memoryCachePolicy(CachePolicy.ENABLED)
-            .diskCachePolicy(CachePolicy.ENABLED)
             .crossfade(true)
             .logger(if (BuildConfig.DEBUG) DebugLogger() else null)
             .build()

--- a/app/src/main/java/com/threegap/bitnagil/BitnagilApplication.kt
+++ b/app/src/main/java/com/threegap/bitnagil/BitnagilApplication.kt
@@ -1,14 +1,52 @@
 package com.threegap.bitnagil
 
 import android.app.Application
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.CachePolicy
+import coil3.request.crossfade
+import coil3.util.DebugLogger
 import com.kakao.sdk.common.KakaoSdk
+import com.threegap.bitnagil.di.core.CoilEntryPoint
+import dagger.hilt.EntryPoints
 import dagger.hilt.android.HiltAndroidApp
+import okio.Path.Companion.toOkioPath
 
 @HiltAndroidApp
-class BitnagilApplication : Application() {
+class BitnagilApplication : Application(), SingletonImageLoader.Factory {
+
     override fun onCreate() {
         super.onCreate()
         initKakaoSdk()
+    }
+
+    override fun newImageLoader(context: PlatformContext): ImageLoader {
+        val okHttpClient = EntryPoints
+            .get(this, CoilEntryPoint::class.java)
+            .noneAuthOkHttpClient()
+
+        return ImageLoader.Builder(context)
+            .components { add(OkHttpNetworkFetcherFactory(callFactory = { okHttpClient })) }
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, percent = 0.25)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache").toOkioPath())
+                    .maxSizeBytes(50L * 1024 * 1024)
+                    .build()
+            }
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .crossfade(true)
+            .logger(if (BuildConfig.DEBUG) DebugLogger() else null)
+            .build()
     }
 
     private fun initKakaoSdk() {

--- a/app/src/main/java/com/threegap/bitnagil/di/core/CoilEntryPoint.kt
+++ b/app/src/main/java/com/threegap/bitnagil/di/core/CoilEntryPoint.kt
@@ -1,0 +1,14 @@
+package com.threegap.bitnagil.di.core
+
+import com.threegap.bitnagil.network.NoneAuth
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface CoilEntryPoint {
+    @NoneAuth
+    fun noneAuthOkHttpClient(): OkHttpClient
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/component/template/CollapsibleHeader.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/screen/home/component/template/CollapsibleHeader.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
 import coil3.compose.AsyncImage
 import com.threegap.bitnagil.designsystem.BitnagilTheme
 import com.threegap.bitnagil.designsystem.R
@@ -53,15 +54,24 @@ fun CollapsibleHeader(
             )
         }
 
-        AsyncImage(
-            model = dailyEmotion.imageUrl,
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .size(baseImageWidth, baseImageHeight),
-            contentDescription = null,
-            placeholder = painterResource(R.drawable.default_emotion),
-            error = painterResource(R.drawable.default_emotion),
-        )
+        if (dailyEmotion.imageUrl.isEmpty()) {
+            Image(
+                painter = painterResource(R.drawable.default_emotion),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(baseImageWidth, baseImageHeight),
+                contentDescription = null,
+            )
+        } else {
+            AsyncImage(
+                model = dailyEmotion.imageUrl,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(baseImageWidth, baseImageHeight),
+                contentDescription = null,
+                error = painterResource(R.drawable.default_emotion),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
# [ PR Content ]
<!---- 변경 사항, 개발 및 관련 이슈에 대해 간단하게 작성해주세요. -->
어제 언급했던 Coil3 커스텀 ImageLoader를 Application 레벨에서 설정했습니다.

## Related issue
- closed #209 

## Screenshot 📸
- N/A

## Work Description
- `CoilEntryPoint` 추가: Hilt EntryPoint를 통해 `@NoneAuth` OkHttpClient 주입
- `BitnagilApplication`에 `SingletonImageLoader.Factory` 구현
  - `components { add(OkHttpNetworkFetcherFactory(...)) }`로 OkHttp 클라이언트 연결
  - 메모리 캐시 25%, 디스크 캐시 50MB, 전역 크로스페이드 활성화
  - DEBUG 빌드에서만 DebugLogger 활성화
- `CollapsibleHeader`: `imageUrl`이 비어있을 때 Coil을 거치지 않고 `Image(painterResource(...))`로 직접 렌더링

## To Reviewers 📢
- 기존에는 Coil 기본 OkHttpClient를 사용했지만, 앱의 `@NoneAuth` OkHttpClient를 재사용하도록 변경하고 메모리/디스크 캐시 전략을 명시적으로 설정했습니다.
- 이외 궁금점은 리뷰 남겨주십쇼!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지 로더 통합으로 메모리(약 25% 제한) 및 디스크(캐시 폴더, 약 50MB) 캐싱을 통해 이미지 로딩 성능과 효율성 개선
  * 이미지 표시 시 부드러운 Crossfade 애니메이션 적용

* **버그 수정**
  * 감정 이미지 URL이 없거나 로드 실패할 때 기본 감정 이미지로 안정적으로 표시되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->