### PR TITLE
[FIX/#217] 카카오 로그인 실패시 강제종료 문제 수정

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,11 +1,22 @@
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
 
-# [Kakao SDK 버그 방어]
-# AccessTokenInterceptor에서 ClientErrorCause 상수를 리플렉션(getField)으로 찾기 때문에 난독화에서 제외함
--keep enum com.kakao.sdk.common.model.ClientErrorCause {
-    *;
-}
+# [Kakao SDK 프로가드 규칙]
+# https://developers.kakao.com/docs/ko/android/getting-started#project-pro-guard
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+
+# https://github.com/square/okhttp/pull/6792
+-dontwarn org.bouncycastle.jsse.**
+-dontwarn org.conscrypt.*
+-dontwarn org.openjsse.**
+
+# refrofit2 (with r8 full mode)
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
 
 # [Kotlinx Serialization]
 # 모든 @Serializable 클래스의 직렬화 로직 및 serializer 메서드 유지

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,7 +10,7 @@
 -dontwarn org.conscrypt.*
 -dontwarn org.openjsse.**
 
-# refrofit2 (with r8 full mode)
+# retrofit2 (with r8 full mode)
 -if interface * { @retrofit2.http.* <methods>; }
 -keep,allowobfuscation interface <1>
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation


### PR DESCRIPTION
# [ PR Content ]
카카오 로그인 실패시 앱이 강제종료되는 문제를 수정했습니다

## Related issue
- closed #217 

## Screenshot 📸
x

## Work Description
- proguard-rules.pro에서 카카오 SDK 관련 부분을 공식 문서 내용으로 대체했습니다

## To Reviewers 📢
- 카카오 공식 문서상에서 제공되는 프로가드 내용에 okhttp/retrofit 부분도 같이 포함되어 있는데, 이 부분이 저희가 기존에 설정한 okhttp/retrofit 부분과 중복되거나 문제되는 부분이 있는지 확인 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 앱 빌드 최적화 설정을 개선했습니다. Kakao SDK 및 Retrofit 라이브러리 호환성을 강화하고, 빌드 프로세스 중 불필요한 경고를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->