### PR TITLE
[Refactor/#219] 상단바 아이콘 색상 변경 로직 수정

### DIFF
--- a/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/MainNavHost.kt
@@ -27,12 +27,15 @@ import com.threegap.bitnagil.presentation.screen.splash.SplashScreenContainer
 import com.threegap.bitnagil.presentation.screen.terms.TermsAgreementScreenContainer
 import com.threegap.bitnagil.presentation.screen.webview.BitnagilWebViewScreen
 import com.threegap.bitnagil.presentation.screen.withdrawal.WithdrawalScreenContainer
+import com.threegap.bitnagil.presentation.util.statusbar.NavStatusBarEffect
 
 @Composable
 fun MainNavHost(
     navigator: MainNavigator,
     modifier: Modifier = Modifier,
 ) {
+    NavStatusBarEffect(navController = navigator.navController)
+
     NavHost(
         navController = navigator.navController,
         startDestination = navigator.startDestination,

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavHost.kt
@@ -3,7 +3,6 @@ package com.threegap.bitnagil.navigation.home
 import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -31,8 +29,8 @@ import com.threegap.bitnagil.designsystem.modifier.clickableWithoutRipple
 import com.threegap.bitnagil.presentation.screen.home.HomeScreenContainer
 import com.threegap.bitnagil.presentation.screen.mypage.MyPageScreenContainer
 import com.threegap.bitnagil.presentation.screen.recommendroutine.RecommendRoutineScreenContainer
+import com.threegap.bitnagil.presentation.util.statusbar.NavStatusBarEffect
 import com.threegap.bitnagil.presentation.util.toast.GlobalBitnagilToast
-import com.threegap.bitnagil.util.setStatusBarContentColor
 
 @Composable
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -54,11 +52,7 @@ fun HomeNavHost(
 
     DoubleBackButtonPressedHandler()
 
-    val activity = LocalActivity.current
-    val isHomeTab = navigator.isHomeRoute
-    LaunchedEffect(isHomeTab) {
-        activity?.setStatusBarContentColor(isLightContent = isHomeTab)
-    }
+    NavStatusBarEffect(navController = navigator.navController)
 
     val selectedBottomTab = navigator.currentHomeRoute ?: navigator.startDestination
 

--- a/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
+++ b/app/src/main/java/com/threegap/bitnagil/navigation/home/HomeNavigator.kt
@@ -23,9 +23,6 @@ class HomeNavigator(
             }
         }
 
-    val isHomeRoute: Boolean
-        @Composable get() = currentHomeRoute == HomeRoute.Home
-
     @Composable
     fun shouldShowFloatingAction(): Boolean = currentHomeRoute?.showFloatingButton == true
 

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/NavStatusBarEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/NavStatusBarEffect.kt
@@ -17,7 +17,7 @@ fun NavStatusBarEffect(navController: NavController) {
     LaunchedEffect(navBackStackEntry) {
         navBackStackEntry?.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             activity?.window?.let { window ->
-                StatusBarAppearanceManager().applyStatusBarColorByLuminance(window)
+                StatusBarAppearanceManager.applyStatusBarColorByLuminance(window)
             }
         }
     }

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/NavStatusBarEffect.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/NavStatusBarEffect.kt
@@ -1,0 +1,24 @@
+package com.threegap.bitnagil.presentation.util.statusbar
+
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+fun NavStatusBarEffect(navController: NavController) {
+    val activity = LocalActivity.current
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+
+    LaunchedEffect(navBackStackEntry) {
+        navBackStackEntry?.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            activity?.window?.let { window ->
+                StatusBarAppearanceManager().applyStatusBarColorByLuminance(window)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/StatusBarAppearanceManager.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/StatusBarAppearanceManager.kt
@@ -1,0 +1,54 @@
+package com.threegap.bitnagil.presentation.util.statusbar
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Rect
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import android.view.Window
+import androidx.core.graphics.createBitmap
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.graphics.get
+import androidx.core.view.WindowInsetsControllerCompat
+
+class StatusBarAppearanceManager {
+    fun applyStatusBarColorByLuminance(window: Window) {
+        val height = getStatusBarHeight(window = window)
+        if (height <= 0) return
+
+        captureStatusBarBitmap(
+            window = window,
+            height = height,
+        ) { bmp ->
+            bmp?.let {
+                val lum = calculateLuminance(it)
+                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = (lum > 150)
+            }
+        }
+    }
+
+    private fun getStatusBarHeight(window: Window): Int {
+        val decorView = window.decorView
+        val insets = ViewCompat.getRootWindowInsets(decorView)
+        return insets?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+    }
+
+    private fun captureStatusBarBitmap(
+        window: Window,
+        height: Int,
+        onResult: (Bitmap?) -> Unit
+    ) {
+        val rect = Rect(0, 0, window.decorView.width, height)
+        val bmp = createBitmap(rect.width(), rect.height())
+        PixelCopy.request(window, rect, bmp, {_ -> onResult(bmp)}, Handler(Looper.getMainLooper()))
+    }
+
+    private fun calculateLuminance(bitmap: Bitmap): Int {
+        val x = bitmap.width / 2
+        val y = bitmap.height / 2
+        val px = bitmap[x, y]
+        return (0.299 * Color.red(px) + 0.587 * Color.green(px) + 0.114 * Color.blue(px)).toInt()
+    }
+}

--- a/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/StatusBarAppearanceManager.kt
+++ b/presentation/src/main/java/com/threegap/bitnagil/presentation/util/statusbar/StatusBarAppearanceManager.kt
@@ -13,7 +13,9 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.graphics.get
 import androidx.core.view.WindowInsetsControllerCompat
 
-class StatusBarAppearanceManager {
+object StatusBarAppearanceManager {
+    private const val LUMINANCE_THRESHOLD = 150
+
     fun applyStatusBarColorByLuminance(window: Window) {
         val height = getStatusBarHeight(window = window)
         if (height <= 0) return
@@ -24,7 +26,8 @@ class StatusBarAppearanceManager {
         ) { bmp ->
             bmp?.let {
                 val lum = calculateLuminance(it)
-                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = (lum > 150)
+                WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = (lum > LUMINANCE_THRESHOLD)
+                it.recycle()
             }
         }
     }
@@ -40,9 +43,28 @@ class StatusBarAppearanceManager {
         height: Int,
         onResult: (Bitmap?) -> Unit
     ) {
+        val width = window.decorView.width
+        if (width <= 0) {
+            onResult(null)
+            return
+        }
+
         val rect = Rect(0, 0, window.decorView.width, height)
         val bmp = createBitmap(rect.width(), rect.height())
-        PixelCopy.request(window, rect, bmp, {_ -> onResult(bmp)}, Handler(Looper.getMainLooper()))
+
+        try {
+            PixelCopy.request(window, rect, bmp, { result ->
+                if (result == PixelCopy.SUCCESS) {
+                    onResult(bmp)
+                } else {
+                    bmp.recycle()
+                    onResult(null)
+                }
+            }, Handler(Looper.getMainLooper()))
+        } catch (_: Exception) {
+            bmp.recycle()
+            onResult(null)
+        }
     }
 
     private fun calculateLuminance(bitmap: Bitmap): Int {


### PR DESCRIPTION
# [ PR Content ]
홈 화면 탭에 한해서만 적용되었던 상단바 아이콘 색상 변경 로직을 모든 화면에 적용될 수 있도록 수정했습니다.

## Related issue
- closed #219 

## Screenshot 📸

기존 동작

https://github.com/user-attachments/assets/f11d9208-036d-4621-a959-e55c3c549367

수정 후 동작

https://github.com/user-attachments/assets/01c0bac1-402d-4b21-b648-b9097f7f1d3f


## Work Description
- 상단 StatusBar 영역의 Pixel값들을 토대로 휘도를 구해 상단 StatusBar 아이콘 색상을 변경하는 로직을 구현했습니다
- 위 로직을 NavBackStackEntry가 변경될 때마다 해당 NavBackStackEntry의 생명주기 중 Resume에서 호출합니다.

## To Reviewers 📢
- 드로이드 나이츠에서 본 기억이 있어 해당 로직을 가져와 사용했습니다!
  - https://youtu.be/fdfhaEvxdy4?si=rOIon7zR4dlesRdY <- 이 영상의 13분 언저리부터 시작되는 부분입니다
- 이전에는 직접 화면에 따라 화면 전환시 바로 아이콘 색상을 변경했기에 아이콘 색상이 변경되는 속도가 빨랐지만, 현재는 NavBackStackEntry의 Resume에서 아이콘 색상이 변경되기에 살짝 반응 속도가 느립니다. 하지만 전체 화면에 적용되는게 더 중요하다고 판단되어 작업을 진행했습니다!
- 궁금한 점 혹은 개선점 있으시면 코멘트 부탁드려요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앱 내 네비게이션에 따라 상태 바 아이콘이 자동으로 조정되어 배경에 대한 가독성이 개선되었습니다.

* **개선 사항**
  * 상태 바 색상 관리 로직이 중앙화되어 더욱 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->