### PR TITLE
[Chore/#223] Claude Code 팀 공유 설정 추가

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./**/build/**)",
+      "Read(./**/.gradle/**)",
+      "Read(./local.properties)",
+      "Read(./**/*.keystore)",
+      "Read(./**/*.jks)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,7 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,kotlin,android,androidstudio
+
+### Claude Code ###
+.claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
# [ PR Content ]
Claude Code 설정을 팀 공유용과 개인 로컬용으로 분리하고, 팀 공유 설정에 민감 파일 접근 차단 규칙을 추가했습니다.

## Related issue
- closed #223

## Screenshot 📸
<!-- 설정 파일 변경으로 스크린샷 없음 -->

## Work Description
- `.claude/settings.json` 추가 (팀 공유)
  - `local.properties`(release keystore 비밀번호 포함), `*.keystore`/`*.jks` 파일 Read 차단
  - 전체 모듈의 `build/`, `.gradle/` 디렉토리 Read 차단 (멀티모듈 전체 커버)
- `.gitignore`에 Claude Code 개인 로컬 설정 항목 추가
  - `.claude/settings.local.json`, `CLAUDE.local.md`는 개인 환경별 설정이므로 커밋 대상에서 제외

## To Reviewers 📢
- deny 규칙은 Claude Code가 해당 파일을 읽지 못하게 하는 보안 설정입니다. 팀에서 추가로 차단이 필요한 파일이 있다면 알려주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안**
  - 빌드 산출물, Gradle 캐시, 로컬 설정 및 서명 키 파일에 대한 무단 접근을 차단하도록 보호 설정을 강화했습니다.

- **개선**
  - 로컬 도구 설정 파일이 저장소에 실수로 포함되지 않도록 자동 제외 항목을 추가했습니다.
  - 개발 환경의 개인 설정과 메타데이터가 버전 관리 대상에서 분리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->